### PR TITLE
Fix/Improve History

### DIFF
--- a/map.cpp
+++ b/map.cpp
@@ -618,7 +618,7 @@ void Map::_floodFillCollisionElevation(int x, int y, uint collision, uint elevat
 
 void Map::undo() {
     if (blockdata) {
-        Blockdata *commit = history.pop();
+        Blockdata *commit = history.back();
         if (commit != NULL) {
             blockdata->copyFrom(commit);
             emit mapChanged(this);
@@ -638,7 +638,7 @@ void Map::redo() {
 
 void Map::commit() {
     if (blockdata) {
-        if (!blockdata->equals(history.history.at(history.head))) {
+        if (!blockdata->equals(history.current())) {
             Blockdata* commit = blockdata->copy();
             history.push(commit);
             emit mapChanged(this);

--- a/map.h
+++ b/map.h
@@ -13,14 +13,10 @@
 template <typename T>
 class History {
 public:
-    QList<T> history;
-    int head = -1;
-    int saved = -1;
-
     History() {
 
     }
-    T pop() {
+    T back() {
         if (head > 0) {
             return history.at(--head);
         }
@@ -42,12 +38,23 @@ public:
         history.append(commit);
         head++;
     }
+    T current() {
+        if (head < 0 || history.length() == 0) {
+            return NULL;
+        }
+        return history.at(head);
+    }
     void save() {
         saved = head;
     }
     bool isSaved() {
         return saved == head;
     }
+
+private:
+    QList<T> history;
+    int head = -1;
+    int saved = -1;
 };
 
 class Connection {


### PR DESCRIPTION
Consumers were accessing the History's internal list and values, which lead to an index out-of-bounds error.  I made those members private, and create a new method called `current()` which returns the current history value and guards against out-of-bounds.
Also renamed `pop()` to `back()` since that made more sense in the context of history, and it's not actually popping the value off.