### PR TITLE
Fix map connections, warps, and map event saving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 pretmap.pro.user
+*.autosave

--- a/event.h
+++ b/event.h
@@ -39,10 +39,6 @@ public:
         values.insert(key, value);
     }
 
-    bool is_hidden_item() {
-        return getInt("type") >= 5;
-    }
-
     QMap<QString, QString> values;
     QPixmap pixmap;
 };

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -513,6 +513,7 @@ void MainWindow::updateSelectedObjects() {
         field_labels["item_unknown6"] = "Unknown 6";
         field_labels["weather"] = "Weather";
         field_labels["flag"] = "Flag";
+        field_labels["secret_base_map"] = "Secret Base Map";
 
         QStringList fields;
 
@@ -561,6 +562,9 @@ void MainWindow::updateSelectedObjects() {
         else if (event_type == "event_hidden_item") {
             fields << "item";
             fields << "flag";
+        }
+        else if (event_type == "event_secret_base") {
+            fields << "secret_base_map";
         }
 
         for (QString key : fields) {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -511,6 +511,8 @@ void MainWindow::updateSelectedObjects() {
         field_labels["item"] = "Item";
         field_labels["item_unknown5"] = "Unknown 5";
         field_labels["item_unknown6"] = "Unknown 6";
+        field_labels["weather"] = "Weather";
+        field_labels["flag"] = "Flag";
 
         QStringList fields;
 
@@ -556,11 +558,9 @@ void MainWindow::updateSelectedObjects() {
             fields << "type";
             fields << "script_label";
         }
-        else if (event_type == "hidden item") {
-            fields << "type";
+        else if (event_type == "event_hidden_item") {
             fields << "item";
-            fields << "item_unknown5";
-            fields << "item_unknown6";
+            fields << "flag";
         }
 
         for (QString key : fields) {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -549,6 +549,9 @@ void MainWindow::updateSelectedObjects() {
             fields << "coord_unknown1";
             fields << "coord_unknown2";
         }
+        else if (event_type == "trap_weather") {
+            fields << "weather";
+        }
         else if (event_type == "sign") {
             fields << "type";
             fields << "script_label";

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -504,7 +504,7 @@ void MainWindow::updateSelectedObjects() {
         field_labels["property"] = "Property";
         field_labels["sight_radius"] = "Sight Radius";
         field_labels["destination_warp"] = "Destination Warp";
-        field_labels["destination_map"] = "Destination Map";
+        field_labels["destination_map_name"] = "Destination Map";
         field_labels["coord_unknown1"] = "Unknown 1";
         field_labels["coord_unknown2"] = "Unknown 2";
         field_labels["type"] = "Type";
@@ -542,7 +542,7 @@ void MainWindow::updateSelectedObjects() {
         }
         else if (event_type == "warp") {
             fields << "destination_warp";
-            fields << "destination_map";
+            fields << "destination_map_name";
         }
         else if (event_type == "trap") {
             fields << "script_label";
@@ -568,7 +568,7 @@ void MainWindow::updateSelectedObjects() {
             combo->setEditable(true);
 
             QString value = item->event->get(key);
-            if (key == "destination_map") {
+            if (key == "destination_map_name") {
                 if (!editor->project->mapNames->contains(value)) {
                     combo->addItem(value);
                 }

--- a/map.cpp
+++ b/map.cpp
@@ -157,22 +157,26 @@ QImage Map::getMetatileImage(int tile) {
     for (int x = 0; x < 2; x++) {
         Tile tile_ = metatile->tiles->value((y * 2) + x + (layer * 4));
         QImage tile_image = getMetatileTile(tile_.tile);
-        //if (tile_image.isNull()) {
-        //    continue;
-        //}
-        //if (blockTileset->palettes) {
-            QList<QRgb> palette = palettes.value(tile_.palette);
-            for (int j = 0; j < palette.length(); j++) {
-                tile_image.setColor(j, palette.value(j));
-            }
-        //}
-        //QVector<QRgb> vector = palette.toVector();
-        //tile_image.setColorTable(vector);
+        if (tile_image.isNull()) {
+            // Some metatiles specify tiles that are outside the valid range.
+            // These are treated as completely transparent, so they can be skipped without
+            // being drawn.
+            continue;
+        }
+
+        // Colorize the metatile tiles with its palette.
+        QList<QRgb> palette = palettes.value(tile_.palette);
+        for (int j = 0; j < palette.length(); j++) {
+            tile_image.setColor(j, palette.value(j));
+        }
+
+        // The top layer of the metatile has its last color displayed at transparent.
         if (layer > 0) {
             QColor color(tile_image.color(15));
             color.setAlpha(0);
             tile_image.setColor(15, color.rgba());
         }
+
         QPoint origin = QPoint(x*8, y*8);
         metatile_painter.drawImage(origin, tile_image.mirrored(tile_.xflip == 1, tile_.yflip == 1));
     }

--- a/map.cpp
+++ b/map.cpp
@@ -4,6 +4,7 @@
 #include <QDebug>
 #include <QPainter>
 #include <QImage>
+#include <QRegularExpression>
 
 Map::Map(QObject *parent) : QObject(parent)
 {
@@ -14,6 +15,24 @@ Map::Map(QObject *parent) : QObject(parent)
     paint_tile = 1;
     paint_collision = 0;
     paint_elevation = 3;
+}
+
+void Map::setName(QString mapName) {
+    name = mapName;
+    constantName = mapConstantFromName(mapName);
+}
+
+QString Map::mapConstantFromName(QString mapName) {
+    // Transform map names of the form 'GraniteCave_B1F` into map constants like 'MAP_GRANITE_CAVE_B1F'.
+    QString nameWithUnderscores = mapName.replace(QRegularExpression("([a-z])([A-Z])"), "\\1_\\2");
+    QString withMapAndUppercase = "MAP_" + nameWithUnderscores.toUpper();
+    QString constantName = withMapAndUppercase.replace(QRegularExpression("_+"), "_");
+
+    // Handle special cases.
+    // SSTidal needs to be SS_TIDAL, rather than SSTIDAL
+    constantName = constantName.replace("SSTIDAL", "SS_TIDAL");
+
+    return constantName;
 }
 
 int Map::getWidth() {

--- a/map.h
+++ b/map.h
@@ -75,6 +75,7 @@ public:
 
 public:
     QString name;
+    QString constantName;
     QString attributes_label;
     QString events_label;
     QString scripts_label;
@@ -102,6 +103,8 @@ public:
     Blockdata* blockdata = NULL;
 
 public:
+    void setName(QString mapName);
+    static QString mapConstantFromName(QString mapName);
     int getWidth();
     int getHeight();
     Tileset* getBlockTileset(int);

--- a/project.cpp
+++ b/project.cpp
@@ -665,7 +665,7 @@ void Project::loadObjectPixmaps(QList<Event*> objects) {
             object->pixmap = QPixmap(":/images/Entities_16x16.png").copy(0, 0, 16, 16);
         } else if (event_type == "warp") {
             object->pixmap = QPixmap(":/images/Entities_16x16.png").copy(16, 0, 16, 16);
-        } else if (event_type == "trap") {
+        } else if (event_type == "trap" || event_type == "trap_weather") {
             object->pixmap = QPixmap(":/images/Entities_16x16.png").copy(32, 0, 16, 16);
         } else if (event_type == "sign" || event_type == "hidden item") {
             object->pixmap = QPixmap(":/images/Entities_16x16.png").copy(48, 0, 16, 16);
@@ -745,7 +745,7 @@ void Project::saveMapEvents(Map *map) {
         text += "\n";
     }
 
-    if (map->events["trap"].length() > 0) {
+    if (map->events["trap"].length() + map->events["trap_weather"].length() > 0) {
         text += QString("%1::\n").arg(map->coord_events_label);
         for (Event *coords : map->events["trap"]) {
             text += QString("\tcoord_event %1").arg(coords->get("x"));
@@ -756,6 +756,13 @@ void Project::saveMapEvents(Map *map) {
             text += QString(", %1").arg(coords->get("coord_unknown2"));
             text += QString(", 0");
             text += QString(", %1").arg(coords->get("script_label"));
+            text += "\n";
+        }
+        for (Event *coords : map->events["trap_weather"]) {
+            text += QString("\tcoord_weather_event %1").arg(coords->get("x"));
+            text += QString(", %1").arg(coords->get("y"));
+            text += QString(", %1").arg(coords->get("elevation"));
+            text += QString(", %1").arg(coords->get("weather"));
             text += "\n";
         }
         text += "\n";
@@ -880,6 +887,7 @@ void Project::readMapEvents(Map *map) {
 
     QList<QStringList> *coords = getLabelMacros(parse(text), map->coord_events_label);
     map->events["trap"].clear();
+    map->events["trap_weather"].clear();
     for (QStringList command : *coords) {
         if (command.value(0) == "coord_event") {
             Event *coord = new Event;
@@ -902,6 +910,16 @@ void Project::readMapEvents(Map *map) {
 
             coord->put("event_type", "trap");
             map->events["trap"].append(coord);
+        } else if (command.value(0) == "coord_weather_event") {
+            Event *coord = new Event;
+            coord->put("map_name", map->name);
+            int i = 1;
+            coord->put("x", command.value(i++));
+            coord->put("y", command.value(i++));
+            coord->put("elevation", command.value(i++));
+            coord->put("weather", command.value(i++));
+            coord->put("event_type", "trap_weather");
+            map->events["trap_weather"].append(coord);
         }
     }
 

--- a/project.cpp
+++ b/project.cpp
@@ -667,7 +667,7 @@ void Project::loadObjectPixmaps(QList<Event*> objects) {
             object->pixmap = QPixmap(":/images/Entities_16x16.png").copy(16, 0, 16, 16);
         } else if (event_type == "trap" || event_type == "trap_weather") {
             object->pixmap = QPixmap(":/images/Entities_16x16.png").copy(32, 0, 16, 16);
-        } else if (event_type == "sign" || event_type == "event_hidden_item") {
+        } else if (event_type == "sign" || event_type == "event_hidden_item" || event_type == "event_secret_base") {
             object->pixmap = QPixmap(":/images/Entities_16x16.png").copy(48, 0, 16, 16);
         }
 
@@ -768,7 +768,10 @@ void Project::saveMapEvents(Map *map) {
         text += "\n";
     }
 
-    if (map->events["sign"].length() + map->events["event_hidden_item"].length() > 0) {
+    if (map->events["sign"].length() +
+        map->events["event_hidden_item"].length() +
+        map->events["event_secret_base"].length() > 0)
+    {
         text += QString("%1::\n").arg(map->bg_events_label);
         for (Event *sign : map->events["sign"]) {
             text += QString("\tbg_event %1").arg(sign->get("x"));
@@ -785,6 +788,13 @@ void Project::saveMapEvents(Map *map) {
             text += QString(", %1").arg(item->get("elevation"));
             text += QString(", %1").arg(item->get("item"));
             text += QString(", %1").arg(item->get("flag"));
+            text += "\n";
+        }
+        for (Event *item : map->events["event_secret_base"]) {
+            text += QString("\tbg_secret_base_event %1").arg(item->get("x"));
+            text += QString(", %1").arg(item->get("y"));
+            text += QString(", %1").arg(item->get("elevation"));
+            text += QString(", %1").arg(item->get("secret_base_map"));
             text += "\n";
         }
         text += "\n";
@@ -921,8 +931,9 @@ void Project::readMapEvents(Map *map) {
     }
 
     QList<QStringList> *bgs = getLabelMacros(parse(text), map->bg_events_label);
-    map->events["event_hidden_item"].clear();
     map->events["sign"].clear();
+    map->events["event_hidden_item"].clear();
+    map->events["event_secret_base"].clear();
     for (QStringList command : *bgs) {
         if (command.value(0) == "bg_event") {
             Event *bg = new Event;
@@ -948,6 +959,16 @@ void Project::readMapEvents(Map *map) {
             bg->put("flag", command.value(i++));
             bg->put("event_type", "event_hidden_item");
             map->events["event_hidden_item"].append(bg);
+        } else if (command.value(0) == "bg_secret_base_event") {
+            Event *bg = new Event;
+            bg->put("map_name", map->name);
+            int i = 1;
+            bg->put("x", command.value(i++));
+            bg->put("y", command.value(i++));
+            bg->put("elevation", command.value(i++));
+            bg->put("secret_base_map", command.value(i++));
+            bg->put("event_type", "event_secret_base");
+            map->events["event_secret_base"].append(bg);
         }
     }
 }

--- a/project.cpp
+++ b/project.cpp
@@ -31,7 +31,7 @@ QString Project::getProjectTitle() {
 Map* Project::loadMap(QString map_name) {
     Map *map = new Map;
 
-    map->name = map_name;
+    map->setName(map_name);
     readMapHeader(map);
     readMapAttributes(map);
     getTilesets(map);
@@ -66,8 +66,13 @@ void Project::loadMapConnections(Map *map) {
                     Connection *connection = new Connection;
                     connection->direction = command.value(1);
                     connection->offset = command.value(2);
-                    connection->map_name = command.value(3);
-                    map->connections.append(connection);
+                    QString mapConstant = command.value(3);
+                    if (mapConstantsToMapNames.contains(mapConstant)) {
+                        connection->map_name = mapConstantsToMapNames[mapConstant];
+                        map->connections.append(connection);
+                    } else {
+                        qDebug() << QString("Failed to find connected map for map constant '%1'").arg(mapConstant);
+                    }
                 }
             }
         }
@@ -515,6 +520,10 @@ void Project::readMapGroups() {
                     QStringList *list = groupedMaps->value(group);
                     list->append(params.value(j));
                     maps->append(params.value(j));
+
+                    // Build the mapping between map constants and map names.
+                    QString mapConstant = Map::mapConstantFromName(params.value(j));
+                    mapConstantsToMapNames.insert(mapConstant, params.value(j));
                 }
             }
         }

--- a/project.cpp
+++ b/project.cpp
@@ -698,85 +698,93 @@ void Project::saveMapEvents(Map *map) {
     QString path = root + QString("/data/maps/events/%1.inc").arg(map->name);
     QString text = "";
 
-    text += QString("%1::\n").arg(map->object_events_label);
-    for (int i = 0; i < map->events["object"].length(); i++) {
-        Event *object_event = map->events["object"].value(i);
-        int radius_x = object_event->getInt("radius_x");
-        int radius_y = object_event->getInt("radius_y");
-        QString radius = QString("%1").arg((radius_x & 0xf) + ((radius_y & 0xf) << 4));
-        uint16_t x = object_event->getInt("x");
-        uint16_t y = object_event->getInt("y");
+    if (map->events["object"].length() > 0) {
+        text += QString("%1::\n").arg(map->object_events_label);
+        for (int i = 0; i < map->events["object"].length(); i++) {
+            Event *object_event = map->events["object"].value(i);
+            int radius_x = object_event->getInt("radius_x");
+            int radius_y = object_event->getInt("radius_y");
+            QString radius = QString("%1").arg((radius_x & 0xf) + ((radius_y & 0xf) << 4));
+            uint16_t x = object_event->getInt("x");
+            uint16_t y = object_event->getInt("y");
 
-        text += QString("\tobject_event %1").arg(i + 1);
-        text += QString(", %1").arg(object_event->get("sprite"));
-        text += QString(", %1").arg(object_event->get("replacement"));
-        text += QString(", %1").arg(x & 0xff);
-        text += QString(", %1").arg((x >> 8) & 0xff);
-        text += QString(", %1").arg(y & 0xff);
-        text += QString(", %1").arg((y >> 8) & 0xff);
-        text += QString(", %1").arg(object_event->get("elevation"));
-        text += QString(", %1").arg(object_event->get("behavior"));
-        text += QString(", %1").arg(radius);
-        text += QString(", 0");
-        text += QString(", %1").arg(object_event->get("property"));
-        text += QString(", 0");
-        text += QString(", %1").arg(object_event->get("sight_radius"));
-        text += QString(", 0");
-        text += QString(", %1").arg(object_event->get("script_label"));
-        text += QString(", %1").arg(object_event->get("event_flag"));
-        text += QString(", 0");
-        text += QString(", 0");
+            text += QString("\tobject_event %1").arg(i + 1);
+            text += QString(", %1").arg(object_event->get("sprite"));
+            text += QString(", %1").arg(object_event->get("replacement"));
+            text += QString(", %1").arg(x & 0xff);
+            text += QString(", %1").arg((x >> 8) & 0xff);
+            text += QString(", %1").arg(y & 0xff);
+            text += QString(", %1").arg((y >> 8) & 0xff);
+            text += QString(", %1").arg(object_event->get("elevation"));
+            text += QString(", %1").arg(object_event->get("behavior"));
+            text += QString(", %1").arg(radius);
+            text += QString(", 0");
+            text += QString(", %1").arg(object_event->get("property"));
+            text += QString(", 0");
+            text += QString(", %1").arg(object_event->get("sight_radius"));
+            text += QString(", 0");
+            text += QString(", %1").arg(object_event->get("script_label"));
+            text += QString(", %1").arg(object_event->get("event_flag"));
+            text += QString(", 0");
+            text += QString(", 0");
+            text += "\n";
+        }
         text += "\n";
     }
-    text += "\n";
 
-    text += QString("%1::\n").arg(map->warps_label);
-    for (Event *warp : map->events["warp"]) {
-        text += QString("\twarp_def %1").arg(warp->get("x"));
-        text += QString(", %1").arg(warp->get("y"));
-        text += QString(", %1").arg(warp->get("elevation"));
-        text += QString(", %1").arg(warp->get("destination_warp"));
-        text += QString(", %1").arg(warp->get("destination_map"));
+    if (map->events["warp"].length() > 0) {
+        text += QString("%1::\n").arg(map->warps_label);
+        for (Event *warp : map->events["warp"]) {
+            text += QString("\twarp_def %1").arg(warp->get("x"));
+            text += QString(", %1").arg(warp->get("y"));
+            text += QString(", %1").arg(warp->get("elevation"));
+            text += QString(", %1").arg(warp->get("destination_warp"));
+            text += QString(", %1").arg(mapNamesToMapConstants[warp->get("destination_map_name")]);
+            text += "\n";
+        }
         text += "\n";
     }
-    text += "\n";
 
-    text += QString("%1::\n").arg(map->coord_events_label);
-    for (Event *coords : map->events["trap"]) {
-        text += QString("\tcoord_event %1").arg(coords->get("x"));
-        text += QString(", %1").arg(coords->get("y"));
-        text += QString(", %1").arg(coords->get("elevation"));
-        text += QString(", 0");
-        text += QString(", %1").arg(coords->get("coord_unknown1"));
-        text += QString(", %1").arg(coords->get("coord_unknown2"));
-        text += QString(", 0");
-        text += QString(", %1").arg(coords->get("script_label"));
+    if (map->events["trap"].length() > 0) {
+        text += QString("%1::\n").arg(map->coord_events_label);
+        for (Event *coords : map->events["trap"]) {
+            text += QString("\tcoord_event %1").arg(coords->get("x"));
+            text += QString(", %1").arg(coords->get("y"));
+            text += QString(", %1").arg(coords->get("elevation"));
+            text += QString(", 0");
+            text += QString(", %1").arg(coords->get("coord_unknown1"));
+            text += QString(", %1").arg(coords->get("coord_unknown2"));
+            text += QString(", 0");
+            text += QString(", %1").arg(coords->get("script_label"));
+            text += "\n";
+        }
         text += "\n";
     }
-    text += "\n";
 
-    text += QString("%1::\n").arg(map->bg_events_label);
-    for (Event *sign : map->events["sign"]) {
-        text += QString("\tbg_event %1").arg(sign->get("x"));
-        text += QString(", %1").arg(sign->get("y"));
-        text += QString(", %1").arg(sign->get("elevation"));
-        text += QString(", %1").arg(sign->get("type"));
-        text += QString(", 0");
-        text += QString(", %1").arg(sign->get("script_label"));
+    if (map->events["sign"].length() + map->events["hidden item"].length() > 0) {
+        text += QString("%1::\n").arg(map->bg_events_label);
+        for (Event *sign : map->events["sign"]) {
+            text += QString("\tbg_event %1").arg(sign->get("x"));
+            text += QString(", %1").arg(sign->get("y"));
+            text += QString(", %1").arg(sign->get("elevation"));
+            text += QString(", %1").arg(sign->get("type"));
+            text += QString(", 0");
+            text += QString(", %1").arg(sign->get("script_label"));
+            text += "\n";
+        }
+        for (Event *item : map->events["hidden item"]) {
+            text += QString("\tbg_event %1").arg(item->get("x"));
+            text += QString(", %1").arg(item->get("y"));
+            text += QString(", %1").arg(item->get("elevation"));
+            text += QString(", %1").arg(item->get("type"));
+            text += QString(", 0");
+            text += QString(", %1").arg(item->get("item"));
+            text += QString(", %1").arg(item->get("item_unknown5"));
+            text += QString(", %1").arg(item->get("item_unknown6"));
+            text += "\n";
+        }
         text += "\n";
     }
-    for (Event *item : map->events["hidden item"]) {
-        text += QString("\tbg_event %1").arg(item->get("x"));
-        text += QString(", %1").arg(item->get("y"));
-        text += QString(", %1").arg(item->get("elevation"));
-        text += QString(", %1").arg(item->get("type"));
-        text += QString(", 0");
-        text += QString(", %1").arg(item->get("item"));
-        text += QString(", %1").arg(item->get("item_unknown5"));
-        text += QString(", %1").arg(item->get("item_unknown6"));
-        text += "\n";
-    }
-    text += "\n";
 
     text += QString("%1::\n").arg(map->events_label);
     text += QString("\tmap_events %1, %2, %3, %4\n")

--- a/project.h
+++ b/project.h
@@ -16,6 +16,7 @@ public:
     QList<QStringList*> *groupedMapNames = NULL;
     QStringList *mapNames = NULL;
     QMap<QString, QString> mapConstantsToMapNames;
+    QMap<QString, QString> mapNamesToMapConstants;
 
     QMap<QString, Map*> *map_cache;
     Map* loadMap(QString);

--- a/project.h
+++ b/project.h
@@ -15,6 +15,7 @@ public:
     QStringList *groupNames = NULL;
     QList<QStringList*> *groupedMapNames = NULL;
     QStringList *mapNames = NULL;
+    QMap<QString, QString> mapConstantsToMapNames;
 
     QMap<QString, Map*> *map_cache;
     Map* loadMap(QString);


### PR DESCRIPTION
To resolve the issue of mapping map constants to map names (e.g. `MAP_GRANITE_CAVE_B1F` -> `GraniteCave_B1F`), I've created two lookup tables when the map groups are read.  This is possible because the map constants can be accurately inferred from the map names.  (SSTidal is the only one that needs a special case.  Maybe there is a better regex to properly capture them all correctly).

This allows map connections to be read correctly, as well as warp destination maps.

Also fixed a bug when saving map events, where it would write out an invalid label for an event group that had no contents.  For example:
`map_events MauvilleCity_MapObjects, MauvilleCity_MapWarps, 0x0, MauvilleCity_MapBGEvents`
It would write out a label for `0x0::` in `MauvilleCity.inc` and cause a compile error.  The solution is to just not write out that label if there are no events for it.