### PR TITLE
Support adding new maps

### DIFF
--- a/asm.cpp
+++ b/asm.cpp
@@ -26,7 +26,7 @@ QList<QStringList>* Asm::parse(QString text) {
         //QString macro;
         //QStringList *params;
         strip_comment(&line);
-        if (line.isEmpty()) {
+        if (line.trimmed().isEmpty()) {
         } else if (line.contains(':')) {
             label = line.left(line.indexOf(':'));
             QStringList *list = new QStringList;

--- a/editor.cpp
+++ b/editor.cpp
@@ -9,14 +9,15 @@ Editor::Editor()
 
 void Editor::saveProject() {
     if (project) {
-        project->saveAllDataStructures();
         project->saveAllMaps();
+        project->saveAllDataStructures();
     }
 }
 
 void Editor::save() {
     if (project && map) {
         project->saveMap(map);
+        project->saveAllDataStructures();
     }
 }
 

--- a/editor.cpp
+++ b/editor.cpp
@@ -9,6 +9,7 @@ Editor::Editor()
 
 void Editor::saveProject() {
     if (project) {
+        project->saveAllDataStructures();
         project->saveAllMaps();
     }
 }

--- a/main.cpp
+++ b/main.cpp
@@ -4,6 +4,7 @@
 int main(int argc, char *argv[])
 {
     QApplication a(argc, argv);
+    a.setStyle("fusion");
     MainWindow w;
     w.show();
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -391,6 +391,8 @@ void MainWindow::onAddNewMapToGroupClick(QAction* triggeredAction)
     int numMapsInGroup = groupItem->rowCount();
     QStandardItem *newMapItem = createMapItem(newMapName, groupNum, numMapsInGroup);
     groupItem->appendRow(newMapItem);
+
+    setMap(newMapName);
 }
 
 void MainWindow::on_mapList_activated(const QModelIndex &index)

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -289,11 +289,12 @@ void MainWindow::populateMapList() {
     QIcon folderIcon;
     folderIcon.addFile(QStringLiteral(":/icons/folder_closed.ico"), QSize(), QIcon::Normal, QIcon::Off);
 
-    QIcon mapIcon;
-    mapIcon.addFile(QStringLiteral(":/icons/map.ico"), QSize(), QIcon::Normal, QIcon::Off);
-    mapIcon.addFile(QStringLiteral(":/icons/image.ico"), QSize(), QIcon::Normal, QIcon::On);
+    mapIcon = new QIcon;
+    mapIcon->addFile(QStringLiteral(":/icons/map.ico"), QSize(), QIcon::Normal, QIcon::Off);
+    mapIcon->addFile(QStringLiteral(":/icons/image.ico"), QSize(), QIcon::Normal, QIcon::On);
 
     mapListModel = new QStandardItemModel;
+    mapGroupsModel = new QList<QStandardItem*>;
 
     QStandardItem *entry = new QStandardItem;
     entry->setText(project->getProjectTitle());
@@ -316,16 +317,13 @@ void MainWindow::populateMapList() {
         group->setEditable(false);
         group->setData(group_name, Qt::UserRole);
         group->setData("map_group", MapListUserRoles::TypeRole);
+        group->setData(i, MapListUserRoles::GroupRole);
         maps->appendRow(group);
+        mapGroupsModel->append(group);
         QStringList *names = project->groupedMapNames->value(i);
         for (int j = 0; j < names->length(); j++) {
             QString map_name = names->value(j);
-            QStandardItem *map = new QStandardItem;
-            map->setText(QString("[%1.%2] ").arg(i).arg(j, 2, 10, QLatin1Char('0')) + map_name);
-            map->setIcon(mapIcon);
-            map->setEditable(false);
-            map->setData(map_name, Qt::UserRole);
-            map->setData("map_name", MapListUserRoles::TypeRole);
+            QStandardItem *map = createMapItem(map_name, i, j);
             group->appendRow(map);
         }
     }
@@ -339,6 +337,16 @@ void MainWindow::populateMapList() {
     ui->mapList->setUpdatesEnabled(true);
     ui->mapList->expandToDepth(2);
     ui->mapList->repaint();
+}
+
+QStandardItem* MainWindow::createMapItem(QString mapName, int groupNum, int inGroupNum) {
+    QStandardItem *map = new QStandardItem;
+    map->setText(QString("[%1.%2] ").arg(groupNum).arg(inGroupNum, 2, 10, QLatin1Char('0')) + mapName);
+    map->setIcon(*mapIcon);
+    map->setEditable(false);
+    map->setData(mapName, Qt::UserRole);
+    map->setData("map_name", MapListUserRoles::TypeRole);
+    return map;
 }
 
 void MainWindow::onOpenMapListContextMenu(const QPoint &point)
@@ -357,18 +365,26 @@ void MainWindow::onOpenMapListContextMenu(const QPoint &point)
     // Build custom context menu depending on which type of item was selected (map group, map name, etc.)
     if (itemType == "map_group") {
         QString groupName = selectedItem->data(Qt::UserRole).toString();
+        int groupNum = selectedItem->data(MapListUserRoles::GroupRole).toInt();
         QMenu* menu = new QMenu();
         QActionGroup* actions = new QActionGroup(menu);
-        actions->addAction(menu->addAction("Add New Map to Group"))->setData(groupName);
-        connect(actions, SIGNAL(triggered(QAction*)), this, SLOT(addNewMapToGroup(QAction*)));
+        actions->addAction(menu->addAction("Add New Map to Group"))->setData(groupNum);
+        connect(actions, SIGNAL(triggered(QAction*)), this, SLOT(onAddNewMapToGroupClick(QAction*)));
         menu->exec(QCursor::pos());
     }
 }
 
-void MainWindow::addNewMapToGroup(QAction* triggeredAction)
+void MainWindow::onAddNewMapToGroupClick(QAction* triggeredAction)
 {
-    QString groupName = triggeredAction->data().toString();
-    qDebug() << "Adding new map " << groupName;
+    int groupNum = triggeredAction->data().toInt();
+    QStandardItem* groupItem = mapGroupsModel->at(groupNum);
+
+    QString newMapName = editor->project->getNewMapName();
+    editor->project->addNewMapToGroup(newMapName, groupNum);
+
+    int numMapsInGroup = groupItem->rowCount();
+    QStandardItem *newMapItem = createMapItem(newMapName, groupNum, numMapsInGroup);
+    groupItem->appendRow(newMapItem);
 }
 
 void MainWindow::on_mapList_activated(const QModelIndex &index)

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -283,6 +283,7 @@ void MainWindow::on_checkBox_ShowLocation_clicked(bool checked)
 void MainWindow::loadDataStructures() {
     Project *project = editor->project;
     project->readMapAttributesTable();
+    project->readAllMapAttributes();
 }
 
 void MainWindow::populateMapList() {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -73,26 +73,26 @@ void MainWindow::openProject(QString dir) {
 
 QString MainWindow::getDefaultMap() {
     if (editor && editor->project) {
-        QList<QStringList*> *names = editor->project->groupedMapNames;
-        if (names) {
+        QList<QStringList> names = editor->project->groupedMapNames;
+        if (!names.isEmpty()) {
             QSettings settings;
             QString key = "project:" + editor->project->root;
             if (settings.contains(key)) {
                 QMap<QString, QVariant> qmap = settings.value(key).toMap();
                 if (qmap.contains("recent_map")) {
                     QString map_name = qmap.value("recent_map").toString();
-                    for (int i = 0; i < names->length(); i++) {
-                        if (names->value(i)->contains(map_name)) {
+                    for (int i = 0; i < names.length(); i++) {
+                        if (names.value(i).contains(map_name)) {
                             return map_name;
                         }
                     }
                 }
             }
             // Failing that, just get the first map in the list.
-            for (int i = 0; i < names->length(); i++) {
-                QStringList *list = names->value(i);
-                if (list->length()) {
-                    return list->value(0);
+            for (int i = 0; i < names.length(); i++) {
+                QStringList list = names.value(i);
+                if (list.length()) {
+                    return list.value(0);
                 }
             }
         }
@@ -327,9 +327,9 @@ void MainWindow::populateMapList() {
         group->setData(i, MapListUserRoles::GroupRole);
         maps->appendRow(group);
         mapGroupsModel->append(group);
-        QStringList *names = project->groupedMapNames->value(i);
-        for (int j = 0; j < names->length(); j++) {
-            QString map_name = names->value(j);
+        QStringList names = project->groupedMapNames.value(i);
+        for (int j = 0; j < names.length(); j++) {
+            QString map_name = names.value(j);
             QStandardItem *map = createMapItem(map_name, i, j);
             group->appendRow(map);
         }
@@ -387,7 +387,9 @@ void MainWindow::onAddNewMapToGroupClick(QAction* triggeredAction)
     QStandardItem* groupItem = mapGroupsModel->at(groupNum);
 
     QString newMapName = editor->project->getNewMapName();
-    editor->project->addNewMapToGroup(newMapName, groupNum);
+    Map* newMap = editor->project->addNewMapToGroup(newMapName, groupNum);
+    editor->project->saveMap(newMap);
+    editor->project->saveAllDataStructures();
 
     int numMapsInGroup = groupItem->rowCount();
     QStandardItem *newMapItem = createMapItem(newMapName, groupNum, numMapsInGroup);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -61,10 +61,12 @@ void MainWindow::openProject(QString dir) {
         editor->project = new Project;
         editor->project->root = dir;
         setWindowTitle(editor->project->getProjectTitle() + " - pretmap");
+        loadDataStructures();
         populateMapList();
         setMap(getDefaultMap());
     } else {
         setWindowTitle(editor->project->getProjectTitle() + " - pretmap");
+        loadDataStructures();
         populateMapList();
     }
 }
@@ -278,6 +280,10 @@ void MainWindow::on_checkBox_ShowLocation_clicked(bool checked)
     }
 }
 
+void MainWindow::loadDataStructures() {
+    Project *project = editor->project;
+    project->readMapAttributesTable();
+}
 
 void MainWindow::populateMapList() {
     Project *project = editor->project;

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -4,6 +4,7 @@
 #include <QString>
 #include <QModelIndex>
 #include <QMainWindow>
+#include <QStandardItemModel>
 #include <QGraphicsPixmapItem>
 #include <QGraphicsItemGroup>
 #include <QGraphicsSceneMouseEvent>
@@ -65,8 +66,12 @@ private slots:
 
     void on_toolButton_Dropper_clicked();
 
+    void onOpenMapListContextMenu(const QPoint &point);
+    void addNewMapToGroup(QAction* triggeredAction);
+
 private:
     Ui::MainWindow *ui;
+    QStandardItemModel *mapListModel;
     Editor *editor = NULL;
     void setMap(QString);
     void populateMapList();
@@ -81,6 +86,10 @@ private:
 
     void displayMapProperties();
     void checkToolButtons();
+};
+
+enum MapListUserRoles {
+    TypeRole = Qt::UserRole + 10, // Used to differentiate between the different layers of the map list tree view.
 };
 
 #endif // MAINWINDOW_H

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -94,7 +94,7 @@ private:
 
 enum MapListUserRoles {
     GroupRole = Qt::UserRole + 1, // Used to hold the map group number.
-    TypeRole = Qt::UserRole + 10, // Used to differentiate between the different layers of the map list tree view.
+    TypeRole = Qt::UserRole + 2,  // Used to differentiate between the different layers of the map list tree view.
 };
 
 #endif // MAINWINDOW_H

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -76,6 +76,7 @@ private:
     Editor *editor = NULL;
     QIcon* mapIcon;
     void setMap(QString);
+    void loadDataStructures();
     void populateMapList();
     QString getExistingDirectory(QString);
     void openProject(QString dir);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -67,18 +67,21 @@ private slots:
     void on_toolButton_Dropper_clicked();
 
     void onOpenMapListContextMenu(const QPoint &point);
-    void addNewMapToGroup(QAction* triggeredAction);
+    void onAddNewMapToGroupClick(QAction* triggeredAction);
 
 private:
     Ui::MainWindow *ui;
     QStandardItemModel *mapListModel;
+    QList<QStandardItem*> *mapGroupsModel;
     Editor *editor = NULL;
+    QIcon* mapIcon;
     void setMap(QString);
     void populateMapList();
     QString getExistingDirectory(QString);
     void openProject(QString dir);
     QString getDefaultMap();
     void setRecentMap(QString map_name);
+    QStandardItem* createMapItem(QString mapName, int groupNum, int inGroupNum);
 
     void markAllEdited(QAbstractItemModel *model);
     void markEdited(QModelIndex index);
@@ -89,6 +92,7 @@ private:
 };
 
 enum MapListUserRoles {
+    GroupRole = Qt::UserRole + 1, // Used to hold the map group number.
     TypeRole = Qt::UserRole + 10, // Used to differentiate between the different layers of the map list tree view.
 };
 

--- a/map.cpp
+++ b/map.cpp
@@ -732,5 +732,5 @@ void Map::addEvent(Event *event) {
 }
 
 bool Map::hasUnsavedChanges() {
-    return !history.isSaved();
+    return !history.isSaved() || !isPersistedToFile;
 }

--- a/map.h
+++ b/map.h
@@ -193,13 +193,4 @@ signals:
 public slots:
 };
 
-class MapGroup : public QObject
-{
-    Q_OBJECT
-public:
-    QString name;
-    int group_num;
-    QList<Map*> maps;
-};
-
 #endif // MAP_H

--- a/map.h
+++ b/map.h
@@ -103,6 +103,8 @@ public:
 
     Blockdata* blockdata = NULL;
 
+    bool isPersistedToFile = true;
+
 public:
     void setName(QString mapName);
     static QString mapConstantFromName(QString mapName);

--- a/map.h
+++ b/map.h
@@ -76,6 +76,7 @@ public:
 public:
     QString name;
     QString constantName;
+    QString group_num;
     QString attributes_label;
     QString events_label;
     QString scripts_label;
@@ -188,6 +189,15 @@ signals:
     void mapChanged(Map *map);
 
 public slots:
+};
+
+class MapGroup : public QObject
+{
+    Q_OBJECT
+public:
+    QString name;
+    int group_num;
+    QList<Map*> maps;
 };
 
 #endif // MAP_H

--- a/project.cpp
+++ b/project.cpp
@@ -466,6 +466,28 @@ void Project::setNewMapAttributes(Map* map) {
     mapAttributes->insert(map->name, attrs);
 }
 
+void Project::saveMapGroupsTable() {
+    QString text = "";
+    int groupNum = 0;
+    for (QStringList* mapNames : *groupedMapNames) {
+        text += QString("\t.align 2\n");
+        text += QString("gMapGroup%1::\n").arg(groupNum);
+        for (QString mapName : *mapNames) {
+            text += QString("\t.4byte %1\n").arg(mapName);
+        }
+        text += QString("\n");
+        groupNum++;
+    }
+
+    text += QString("\t.align 2\n");
+    text += QString("gMapGroups::\n");
+    for (int i = 0; i < groupNum; i++) {
+        text += QString("\t.4byte gMapGroup%1\n").arg(i);
+    }
+
+    saveTextFile(root + "/data/maps/_groups.inc", text);
+}
+
 void Project::getTilesets(Map* map) {
     map->tileset_primary = getTileset(map->tileset_primary_label);
     map->tileset_secondary = getTileset(map->tileset_secondary_label);
@@ -614,12 +636,13 @@ void Project::saveMap(Map *map) {
     saveMapHeader(map);
     saveBlockdata(map);
     saveMapEvents(map);
+    map->isPersistedToFile = true;
 }
 
 void Project::saveAllDataStructures() {
     saveMapAttributesTable();
     saveAllMapAttributes();
-    // TODO: saveMapGroupsTable();
+    saveMapGroupsTable();
 }
 
 void Project::loadTilesetAssets(Tileset* tileset) {

--- a/project.cpp
+++ b/project.cpp
@@ -451,6 +451,19 @@ void Project::setNewMapAttributes(Map* map) {
     map->blockdata_label = QString("%1_MapBlockdata").arg(map->name);
     map->tileset_primary_label = "gTileset_General";
     map->tileset_secondary_label = "gTileset_Petalburg";
+
+    // Insert new entry into the global map attributes.
+    QMap<QString, QString>* attrs = new QMap<QString, QString>;
+    attrs->insert("border_label", QString("%1_MapBorder").arg(map->name));
+    attrs->insert("border_filepath", QString("data/maps/%1/border.bin").arg(map->name));
+    attrs->insert("blockdata_label", QString("%1_MapBlockdata").arg(map->name));
+    attrs->insert("blockdata_filepath", QString("data/maps/%1/map.bin").arg(map->name));
+    attrs->insert("attributes_label", QString("%1_MapAttributes").arg(map->name));
+    attrs->insert("width", map->width);
+    attrs->insert("height", map->height);
+    attrs->insert("tileset_primary", map->tileset_primary_label);
+    attrs->insert("tileset_secondary", map->tileset_secondary_label);
+    mapAttributes->insert(map->name, attrs);
 }
 
 void Project::getTilesets(Map* map) {

--- a/project.cpp
+++ b/project.cpp
@@ -232,6 +232,7 @@ void Project::readMapAttributesTable() {
         }
     }
 
+    // Deep copy
     mapAttributesTableMaster = mapAttributesTable;
     mapAttributesTableMaster.detach();
 }
@@ -357,7 +358,6 @@ void Project::readAllMapAttributes() {
             if (!mapAttributes.contains(altMapName)) {
                 mapAttributes.insert(altMapName, QMap<QString, QString>());
             }
-            mapAttributes[altMapName]["attributes_label"] = attributeMapLabel;
             mapAttributes[altMapName].insert("attributes_label", attributeMapLabel);
             mapAttributes[altMapName].insert("width", attrWidth);
             mapAttributes[altMapName].insert("height", attrHeight);
@@ -372,6 +372,7 @@ void Project::readAllMapAttributes() {
         }
     }
 
+    // Deep copy
     mapAttributesMaster = mapAttributes;
     mapAttributesMaster.detach();
 }
@@ -687,6 +688,7 @@ void Project::saveMap(Map *map) {
 void Project::updateMapAttributes(Map* map) {
     mapAttributesTableMaster.insert(map->index.toInt(nullptr, 0), map->name);
 
+    // Deep copy
     QMap<QString, QString> attrs = mapAttributes.value(map->name);
     attrs.detach();
     mapAttributesMaster.insert(map->name, attrs);

--- a/project.h
+++ b/project.h
@@ -48,6 +48,13 @@ public:
     void getTilesets(Map*);
     void loadTilesetAssets(Tileset*);
 
+    void setNewMapHeader(Map* map, int mapIndex);
+    void setNewMapAttributes(Map* map);
+    void setNewMapBlockdata(Map* map);
+    void setNewMapBorder(Map *map);
+    void setNewMapEvents(Map *map);
+    void setNewMapConnections(Map *map);
+
     QString getBlockdataPath(Map*);
     void saveBlockdata(Map*);
     void writeBlockdata(QString, Blockdata*);

--- a/project.h
+++ b/project.h
@@ -20,6 +20,8 @@ public:
     QMap<QString, QString> *mapConstantsToMapNames;
     QMap<QString, QString> *mapNamesToMapConstants;
     QMap<int, QString> *mapAttributesTable;
+    QMap<QString, QMap<QString, QString>*> *mapAttributes;
+
 
     QMap<QString, Map*> *map_cache;
     Map* loadMap(QString);
@@ -44,6 +46,7 @@ public:
     QStringList* getLabelValues(QList<QStringList>*, QString);
     void readMapHeader(Map*);
     void readMapAttributesTable();
+    void readAllMapAttributes();
     void readMapAttributes(Map*);
     void getTilesets(Map*);
     void loadTilesetAssets(Tileset*);

--- a/project.h
+++ b/project.h
@@ -64,6 +64,7 @@ public:
     void saveAllMaps();
     void saveMap(Map*);
     void saveAllDataStructures();
+    void saveAllMapAttributes();
 
     QList<QStringList>* parse(QString text);
     QStringList getSongNames();
@@ -91,6 +92,7 @@ public:
     QMap<QString, int> readCDefines(QString text, QStringList prefixes);
 private:
     QString getMapAttributesTableFilepath();
+    QString getMapAssetsFilepath();
     void saveMapHeader(Map*);
     void saveMapAttributesTable();
 };

--- a/project.h
+++ b/project.h
@@ -19,6 +19,7 @@ public:
     QStringList *mapNames = NULL;
     QMap<QString, QString> *mapConstantsToMapNames;
     QMap<QString, QString> *mapNamesToMapConstants;
+    QMap<int, QString> *mapAttributesTable;
 
     QMap<QString, Map*> *map_cache;
     Map* loadMap(QString);
@@ -42,6 +43,7 @@ public:
     QList<QStringList>* getLabelMacros(QList<QStringList>*, QString);
     QStringList* getLabelValues(QList<QStringList>*, QString);
     void readMapHeader(Map*);
+    void readMapAttributesTable();
     void readMapAttributes(Map*);
     void getTilesets(Map*);
     void loadTilesetAssets(Tileset*);
@@ -51,7 +53,7 @@ public:
     void writeBlockdata(QString, Blockdata*);
     void saveAllMaps();
     void saveMap(Map*);
-    void saveMapHeader(Map*);
+    void saveAllDataStructures();
 
     QList<QStringList>* parse(QString text);
     QStringList getSongNames();
@@ -77,6 +79,10 @@ public:
     QStringList readCArray(QString text, QString label);
     QString readCIncbin(QString text, QString label);
     QMap<QString, int> readCDefines(QString text, QStringList prefixes);
+private:
+    QString getMapAttributesTableFilepath();
+    void saveMapHeader(Map*);
+    void saveMapAttributesTable();
 };
 
 #endif // PROJECT_H

--- a/project.h
+++ b/project.h
@@ -54,13 +54,6 @@ public:
     void getTilesets(Map*);
     void loadTilesetAssets(Tileset*);
 
-    void setNewMapHeader(Map* map, int mapIndex);
-    void setNewMapAttributes(Map* map);
-    void setNewMapBlockdata(Map* map);
-    void setNewMapBorder(Map *map);
-    void setNewMapEvents(Map *map);
-    void setNewMapConnections(Map *map);
-
     QString getBlockdataPath(Map*);
     void saveBlockdata(Map*);
     void saveMapBorder(Map*);
@@ -102,6 +95,13 @@ private:
     void saveMapHeader(Map*);
     void saveMapAttributesTable();
     void updateMapAttributes(Map* map);
+
+    void setNewMapHeader(Map* map, int mapIndex);
+    void setNewMapAttributes(Map* map);
+    void setNewMapBlockdata(Map* map);
+    void setNewMapBorder(Map *map);
+    void setNewMapEvents(Map *map);
+    void setNewMapConnections(Map *map);
 };
 
 #endif // PROJECT_H

--- a/project.h
+++ b/project.h
@@ -70,6 +70,7 @@ public:
     void saveAllDataStructures();
     void saveAllMapAttributes();
     void saveMapGroupsTable();
+    void saveMapConstantsHeader();
 
     QList<QStringList>* parse(QString text);
     QStringList getSongNames();

--- a/project.h
+++ b/project.h
@@ -6,6 +6,7 @@
 
 #include <QStringList>
 #include <QList>
+#include <QStandardItem>
 
 class Project
 {
@@ -13,10 +14,11 @@ public:
     Project();
     QString root;
     QStringList *groupNames = NULL;
+    QMap<QString, int> *map_groups;
     QList<QStringList*> *groupedMapNames = NULL;
     QStringList *mapNames = NULL;
-    QMap<QString, QString> mapConstantsToMapNames;
-    QMap<QString, QString> mapNamesToMapConstants;
+    QMap<QString, QString> *mapConstantsToMapNames;
+    QMap<QString, QString> *mapNamesToMapConstants;
 
     QMap<QString, Map*> *map_cache;
     Map* loadMap(QString);
@@ -33,6 +35,8 @@ public:
     void saveTextFile(QString path, QString text);
 
     void readMapGroups();
+    void addNewMapToGroup(QString mapName, int groupNum);
+    QString getNewMapName();
     QString getProjectTitle();
 
     QList<QStringList>* getLabelMacros(QList<QStringList>*, QString);

--- a/project.h
+++ b/project.h
@@ -15,12 +15,14 @@ public:
     QString root;
     QStringList *groupNames = NULL;
     QMap<QString, int> *map_groups;
-    QList<QStringList*> *groupedMapNames = NULL;
+    QList<QStringList> groupedMapNames;
     QStringList *mapNames = NULL;
-    QMap<QString, QString> *mapConstantsToMapNames;
-    QMap<QString, QString> *mapNamesToMapConstants;
-    QMap<int, QString> *mapAttributesTable;
-    QMap<QString, QMap<QString, QString>*> *mapAttributes;
+    QMap<QString, QString>* mapConstantsToMapNames;
+    QMap<QString, QString>* mapNamesToMapConstants;
+    QMap<int, QString> mapAttributesTable;
+    QMap<int, QString> mapAttributesTableMaster;
+    QMap<QString, QMap<QString, QString>> mapAttributes;
+    QMap<QString, QMap<QString, QString>> mapAttributesMaster;
 
 
     QMap<QString, Map*> *map_cache;
@@ -39,7 +41,7 @@ public:
     void appendTextFile(QString path, QString text);
 
     void readMapGroups();
-    void addNewMapToGroup(QString mapName, int groupNum);
+    Map* addNewMapToGroup(QString mapName, int groupNum);
     QString getNewMapName();
     QString getProjectTitle();
 
@@ -98,6 +100,7 @@ private:
     QString getMapAssetsFilepath();
     void saveMapHeader(Map*);
     void saveMapAttributesTable();
+    void updateMapAttributes(Map* map);
 };
 
 #endif // PROJECT_H

--- a/project.h
+++ b/project.h
@@ -67,6 +67,7 @@ public:
     void saveMap(Map*);
     void saveAllDataStructures();
     void saveAllMapAttributes();
+    void saveMapGroupsTable();
 
     QList<QStringList>* parse(QString text);
     QStringList getSongNames();

--- a/project.h
+++ b/project.h
@@ -36,6 +36,7 @@ public:
 
     QString readTextFile(QString path);
     void saveTextFile(QString path, QString text);
+    void appendTextFile(QString path, QString text);
 
     void readMapGroups();
     void addNewMapToGroup(QString mapName, int groupNum);
@@ -60,6 +61,7 @@ public:
 
     QString getBlockdataPath(Map*);
     void saveBlockdata(Map*);
+    void saveMapBorder(Map*);
     void writeBlockdata(QString, Blockdata*);
     void saveAllMaps();
     void saveMap(Map*);


### PR DESCRIPTION
There's a fair amount of work that went in to enable this feature.  To add a new map, you right-click on the map group and it brings up a context menu to add a new map.  Rather than writing directly to all the necessary files immediately, it sets up a new `Map` object for it, and then proceeds to save it as if it were any other previously-existing map.  To enable this behavior, certain data structures are parsed from the project initially, such as the map attributes table and the contents of `_assets.inc`.  That way, it's simple to save those data structures to their respective files when saving a map.

There is a new field in the `Map` class called `isPersistedToFile`.  This was meant to differentiate between files that actually exist on disk vs. new maps that haven't been written to disk.  Currently, this member is effectively unused (but functional) since new maps are saved immediately after creating them in memory.  I chose to do this because of undefined behavior that I'm punting.  (What happens when you create multiple new maps in the same group?  You need to retroactively go and fix the ordering and map indexes if those are individually saved in a different order than they were created.)  If there is demand for creating new maps without immediately saving them to disk, then it will be addressed.

#10 