### PR TITLE
Display hovered map tile and block info

### DIFF
--- a/editor.cpp
+++ b/editor.cpp
@@ -257,6 +257,25 @@ void MetatilesPixmapItem::pick(uint tile) {
     emit map->paintTileChanged(map);
 }
 
+void MetatilesPixmapItem::updateCurHoveredMetatile(QPointF pos) {
+    int x = ((int)pos.x()) / 16;
+    int y = ((int)pos.y()) / 16;
+    int width = pixmap().width() / 16;
+    int height = pixmap().height() / 16;
+    if (x < 0 || x >= width || y < 0 || y >= height) {
+        map->clearHoveredMetatile();
+    } else {
+        int block = y * width + x;
+        map->hoveredMetatileChanged(block);
+    }
+}
+
+void MetatilesPixmapItem::hoverMoveEvent(QGraphicsSceneHoverEvent *event) {
+    updateCurHoveredMetatile(event->pos());
+}
+void MetatilesPixmapItem::hoverLeaveEvent(QGraphicsSceneHoverEvent *event) {
+    map->clearHoveredMetatile();
+}
 void MetatilesPixmapItem::mousePressEvent(QGraphicsSceneMouseEvent *event) {
     QPointF pos = event->pos();
     int x = ((int)pos.x()) / 16;
@@ -269,6 +288,7 @@ void MetatilesPixmapItem::mousePressEvent(QGraphicsSceneMouseEvent *event) {
     }
 }
 void MetatilesPixmapItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event) {
+    updateCurHoveredMetatile(event->pos());
     mousePressEvent(event);
 }
 void MetatilesPixmapItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event) {

--- a/editor.cpp
+++ b/editor.cpp
@@ -295,6 +295,31 @@ void MetatilesPixmapItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event) {
     mousePressEvent(event);
 }
 
+void CollisionMetatilesPixmapItem::updateCurHoveredMetatile(QPointF pos) {
+    int x = ((int)pos.x()) / 16;
+    int y = ((int)pos.y()) / 16;
+    int width = pixmap().width() / 16;
+    int height = pixmap().height() / 16;
+    if (x < 0 || x >= width || y < 0 || y >= height) {
+        map->clearHoveredCollisionTile();
+    } else {
+        int collision = y * width + x;
+        map->hoveredCollisionTileChanged(collision);
+    }
+}
+
+void ElevationMetatilesPixmapItem::updateCurHoveredMetatile(QPointF pos) {
+    int x = ((int)pos.x()) / 16;
+    int y = ((int)pos.y()) / 16;
+    int width = pixmap().width() / 16;
+    int height = pixmap().height() / 16;
+    if (x < 0 || x >= width || y < 0 || y >= height) {
+        map->clearHoveredElevationTile();
+    } else {
+        int elevation = y * width + x;
+        map->hoveredElevationTileChanged(elevation);
+    }
+}
 
 void MapPixmapItem::paint(QGraphicsSceneMouseEvent *event) {
     if (map) {

--- a/editor.cpp
+++ b/editor.cpp
@@ -368,10 +368,29 @@ void MapPixmapItem::redo() {
     }
 }
 
+void MapPixmapItem::updateCurHoveredTile(QPointF pos) {
+    int x = ((int)pos.x()) / 16;
+    int y = ((int)pos.y()) / 16;
+    int blockIndex = y * map->getWidth() + x;
+    if (x < 0 || x >= map->getWidth() || y < 0 || y >= map->getHeight()) {
+        map->clearHoveredTile();
+    } else {
+        int tile = map->blockdata->blocks->at(blockIndex).tile;
+        map->hoveredTileChanged(x, y, tile);
+    }
+}
+
+void MapPixmapItem::hoverMoveEvent(QGraphicsSceneHoverEvent *event) {
+    updateCurHoveredTile(event->pos());
+}
+void MapPixmapItem::hoverLeaveEvent(QGraphicsSceneHoverEvent *event) {
+    map->clearHoveredTile();
+}
 void MapPixmapItem::mousePressEvent(QGraphicsSceneMouseEvent *event) {
     emit mouseEvent(event, this);
 }
 void MapPixmapItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event) {
+    updateCurHoveredTile(event->pos());
     emit mouseEvent(event, this);
 }
 void MapPixmapItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event) {

--- a/editor.h
+++ b/editor.h
@@ -241,14 +241,19 @@ public:
     }
     MetatilesPixmapItem(Map *map_) {
         map = map_;
+        setAcceptHoverEvents(true);
         connect(map, SIGNAL(paintTileChanged(Map*)), this, SLOT(paintTileChanged(Map *)));
     }
     Map* map = NULL;
     virtual void pick(uint);
     virtual void draw();
+private:
+    void updateCurHoveredMetatile(QPointF pos);
 private slots:
     void paintTileChanged(Map *map);
 protected:
+    void hoverMoveEvent(QGraphicsSceneHoverEvent*);
+    void hoverLeaveEvent(QGraphicsSceneHoverEvent*);
     void mousePressEvent(QGraphicsSceneMouseEvent*);
     void mouseMoveEvent(QGraphicsSceneMouseEvent*);
     void mouseReleaseEvent(QGraphicsSceneMouseEvent*);

--- a/editor.h
+++ b/editor.h
@@ -185,6 +185,7 @@ public:
     Map *map = NULL;
     MapPixmapItem(Map *map_) {
         map = map_;
+        setAcceptHoverEvents(true);
     }
     bool active;
     bool right_click;
@@ -198,10 +199,15 @@ public:
     virtual void redo();
     virtual void draw();
 
+private:
+    void updateCurHoveredTile(QPointF pos);
+
 signals:
     void mouseEvent(QGraphicsSceneMouseEvent *, MapPixmapItem *);
 
 protected:
+    void hoverMoveEvent(QGraphicsSceneHoverEvent*);
+    void hoverLeaveEvent(QGraphicsSceneHoverEvent*);
     void mousePressEvent(QGraphicsSceneMouseEvent*);
     void mouseMoveEvent(QGraphicsSceneMouseEvent*);
     void mouseReleaseEvent(QGraphicsSceneMouseEvent*);

--- a/editor.h
+++ b/editor.h
@@ -247,8 +247,8 @@ public:
     Map* map = NULL;
     virtual void pick(uint);
     virtual void draw();
-private:
-    void updateCurHoveredMetatile(QPointF pos);
+protected:
+    virtual void updateCurHoveredMetatile(QPointF pos);
 private slots:
     void paintTileChanged(Map *map);
 protected:
@@ -272,6 +272,8 @@ public:
     virtual void draw() {
         setPixmap(map->renderCollisionMetatiles());
     }
+protected:
+    virtual void updateCurHoveredMetatile(QPointF pos);
 private slots:
     void paintCollisionChanged(Map *map) {
         draw();
@@ -291,6 +293,8 @@ public:
     virtual void draw() {
         setPixmap(map->renderElevationMetatiles());
     }
+protected:
+    virtual void updateCurHoveredMetatile(QPointF pos);
 private slots:
     void paintCollisionChanged(Map *map) {
         draw();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -48,10 +48,17 @@ MainWindow::~MainWindow()
     delete ui;
 }
 
+void MainWindow::setStatusBarMessage(QString message, int timeout/* = 0*/) {
+    statusBar()->showMessage(message, timeout);
+}
+
 void MainWindow::openProject(QString dir) {
     if (dir.isNull()) {
         return;
     }
+
+    setStatusBarMessage(QString("Opening project %1").arg(dir));
+
     bool already_open = (
         (editor != NULL && editor != nullptr)
         && (editor->project != NULL && editor->project != nullptr)
@@ -69,6 +76,8 @@ void MainWindow::openProject(QString dir) {
         loadDataStructures();
         populateMapList();
     }
+
+    setStatusBarMessage(QString("Opened project %1").arg(dir));
 }
 
 QString MainWindow::getDefaultMap() {
@@ -169,6 +178,7 @@ void MainWindow::setMap(QString map_name) {
     setWindowTitle(map_name + " - " + editor->project->getProjectTitle() + " - pretmap");
 
     connect(editor->map, SIGNAL(mapChanged(Map*)), this, SLOT(onMapChanged(Map *)));
+    connect(editor->map, SIGNAL(statusBarMessage(QString)), this, SLOT(setStatusBarMessage(QString)));
 
     setRecentMap(map_name);
     updateMapList();

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -25,6 +25,9 @@ public:
     explicit MainWindow(QWidget *parent = 0);
     ~MainWindow();
 
+public slots:
+    void setStatusBarMessage(QString message, int timeout = 0);
+
 private slots:
     void on_action_Open_Project_triggered();
     void on_mapList_activated(const QModelIndex &index);

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -1217,14 +1217,6 @@
    <addaction name="menuFile"/>
    <addaction name="menuEdit"/>
   </widget>
-  <widget class="QToolBar" name="mainToolBar">
-   <attribute name="toolBarArea">
-    <enum>TopToolBarArea</enum>
-   </attribute>
-   <attribute name="toolBarBreak">
-    <bool>false</bool>
-   </attribute>
-  </widget>
   <widget class="QStatusBar" name="statusBar"/>
   <action name="action_Save_Project">
    <property name="text">

--- a/map.cpp
+++ b/map.cpp
@@ -754,3 +754,19 @@ void Map::hoveredMetatileChanged(int block) {
 void Map::clearHoveredMetatile() {
     emit statusBarMessage(QString(""));
 }
+
+void Map::hoveredCollisionTileChanged(int collision) {
+    emit statusBarMessage(QString("Collision: %1").arg(collision));
+}
+
+void Map::clearHoveredCollisionTile() {
+    emit statusBarMessage(QString(""));
+}
+
+void Map::hoveredElevationTileChanged(int elevation) {
+    emit statusBarMessage(QString("Elevation: %1").arg(elevation));
+}
+
+void Map::clearHoveredElevationTile() {
+    emit statusBarMessage(QString(""));
+}

--- a/map.cpp
+++ b/map.cpp
@@ -734,3 +734,14 @@ void Map::addEvent(Event *event) {
 bool Map::hasUnsavedChanges() {
     return !history.isSaved() || !isPersistedToFile;
 }
+
+void Map::hoveredTileChanged(int x, int y, int block) {
+    emit statusBarMessage(QString("X: %1, Y: %2, Block: 0x%3")
+                          .arg(x)
+                          .arg(y)
+                          .arg(QString("%1").arg(block, 3, 16, QChar('0')).toUpper()));
+}
+
+void Map::clearHoveredTile() {
+    emit statusBarMessage(QString(""));
+}

--- a/map.cpp
+++ b/map.cpp
@@ -745,3 +745,12 @@ void Map::hoveredTileChanged(int x, int y, int block) {
 void Map::clearHoveredTile() {
     emit statusBarMessage(QString(""));
 }
+
+void Map::hoveredMetatileChanged(int block) {
+    emit statusBarMessage(QString("Block: 0x%1")
+                          .arg(QString("%1").arg(block, 3, 16, QChar('0')).toUpper()));
+}
+
+void Map::clearHoveredMetatile() {
+    emit statusBarMessage(QString(""));
+}

--- a/map.h
+++ b/map.h
@@ -186,6 +186,10 @@ public:
     void clearHoveredTile();
     void hoveredMetatileChanged(int block);
     void clearHoveredMetatile();
+    void hoveredCollisionTileChanged(int collision);
+    void clearHoveredCollisionTile();
+    void hoveredElevationTileChanged(int elevation);
+    void clearHoveredElevationTile();
 
     QList<QList<QRgb> > getBlockPalettes(int metatile_index);
 

--- a/map.h
+++ b/map.h
@@ -184,6 +184,8 @@ public:
     bool hasUnsavedChanges();
     void hoveredTileChanged(int x, int y, int block);
     void clearHoveredTile();
+    void hoveredMetatileChanged(int block);
+    void clearHoveredMetatile();
 
     QList<QList<QRgb> > getBlockPalettes(int metatile_index);
 

--- a/map.h
+++ b/map.h
@@ -182,6 +182,8 @@ public:
     void cacheBorder();
 
     bool hasUnsavedChanges();
+    void hoveredTileChanged(int x, int y, int block);
+    void clearHoveredTile();
 
     QList<QList<QRgb> > getBlockPalettes(int metatile_index);
 
@@ -189,6 +191,7 @@ signals:
     void paintTileChanged(Map *map);
     void paintCollisionChanged(Map *map);
     void mapChanged(Map *map);
+    void statusBarMessage(QString);
 
 public slots:
 };


### PR DESCRIPTION
#11 

When mouse is hovering over the map editor:
![image](https://user-images.githubusercontent.com/2229288/36949196-e5430b2e-1f99-11e8-936f-d45a7b9abec9.png)


When mouse is hovering over the block selection:
![image](https://user-images.githubusercontent.com/2229288/36949199-f3b46c70-1f99-11e8-8227-f6d302783ae2.png)

Collision and elevation selection:
![image](https://user-images.githubusercontent.com/2229288/36949207-01911398-1f9a-11e8-8162-af2eaa4d264a.png)
![image](https://user-images.githubusercontent.com/2229288/36949209-09df6e6e-1f9a-11e8-9e0d-aa3cde4b6578.png)
