### PR TITLE
Add ability to export map image

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -759,3 +759,12 @@ void MainWindow::checkToolButtons() {
 void MainWindow::onMapChanged(Map *map) {
     updateMapList();
 }
+
+void MainWindow::on_action_Export_Map_Image_triggered()
+{
+    QString defaultFilepath = QString("%1/%2.png").arg(editor->project->root).arg(editor->map->name);
+    QString filepath = QFileDialog::getSaveFileName(this, "Export Map Image", defaultFilepath, "Image Files (*.png *.jpg *.bmp)");
+    if (!filepath.isEmpty()) {
+        editor->map_item->pixmap().save(filepath);
+    }
+}

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -72,7 +72,7 @@ private slots:
     void onOpenMapListContextMenu(const QPoint &point);
     void onAddNewMapToGroupClick(QAction* triggeredAction);
 
-    void on_checkBox_ToggleGrid_toggled(bool checked);
+    void on_action_Export_Map_Image_triggered();
 
 private:
     Ui::MainWindow *ui;

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -1221,6 +1221,8 @@
     <addaction name="action_Save"/>
     <addaction name="action_Save_Project"/>
     <addaction name="separator"/>
+    <addaction name="action_Export_Map_Image"/>
+    <addaction name="separator"/>
     <addaction name="action_Exit"/>
    </widget>
    <widget class="QMenu" name="menuEdit">
@@ -1283,6 +1285,11 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Y</string>
+   </property>
+  </action>
+  <action name="action_Export_Map_Image">
+   <property name="text">
+    <string>Export Map Image...</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Added a new action to the File menu called "Export Map Image...", which presents the user a save dialog, and saves an image of the map (not including the connections/border).
#6 