### PR TITLE
Fix collision and elevation selections

### DIFF
--- a/editor.cpp
+++ b/editor.cpp
@@ -332,6 +332,24 @@ void MetatilesPixmapItem::updateSelection(QPointF pos, Qt::MouseButton button) {
     }
 }
 
+void MovementPermissionsPixmapItem::mousePressEvent(QGraphicsSceneMouseEvent* event) {
+    QPointF pos = event->pos();
+    int x = ((int)pos.x()) / 16;
+    int y = ((int)pos.y()) / 16;
+    int width = pixmap().width() / 16;
+    int height = pixmap().height() / 16;
+    if ((x >= 0 && x < width) && (y >=0 && y < height)) {
+        pick(y * width + x);
+    }
+}
+void MovementPermissionsPixmapItem::mouseMoveEvent(QGraphicsSceneMouseEvent* event) {
+    updateCurHoveredMetatile(event->pos());
+    mousePressEvent(event);
+}
+void MovementPermissionsPixmapItem::mouseReleaseEvent(QGraphicsSceneMouseEvent* event) {
+    mousePressEvent(event);
+}
+
 void CollisionMetatilesPixmapItem::updateCurHoveredMetatile(QPointF pos) {
     int x = ((int)pos.x()) / 16;
     int y = ((int)pos.y()) / 16;

--- a/editor.h
+++ b/editor.h
@@ -266,10 +266,24 @@ protected:
     void mouseReleaseEvent(QGraphicsSceneMouseEvent*);
 };
 
-class CollisionMetatilesPixmapItem : public MetatilesPixmapItem {
+class MovementPermissionsPixmapItem : public MetatilesPixmapItem {
     Q_OBJECT
 public:
-    CollisionMetatilesPixmapItem(Map *map_): MetatilesPixmapItem(map_) {
+    MovementPermissionsPixmapItem(Map *map_): MetatilesPixmapItem(map_) {}
+    virtual void pick(uint collision) {
+        map->paint_collision = collision;
+        draw();
+    }
+protected:
+    void mousePressEvent(QGraphicsSceneMouseEvent*);
+    void mouseMoveEvent(QGraphicsSceneMouseEvent*);
+    void mouseReleaseEvent(QGraphicsSceneMouseEvent*);
+};
+
+class CollisionMetatilesPixmapItem : public MovementPermissionsPixmapItem {
+    Q_OBJECT
+public:
+    CollisionMetatilesPixmapItem(Map *map_): MovementPermissionsPixmapItem(map_) {
         connect(map, SIGNAL(paintCollisionChanged(Map*)), this, SLOT(paintCollisionChanged(Map *)));
     }
     virtual void pick(uint collision) {
@@ -287,10 +301,10 @@ private slots:
     }
 };
 
-class ElevationMetatilesPixmapItem : public MetatilesPixmapItem {
+class ElevationMetatilesPixmapItem : public MovementPermissionsPixmapItem {
     Q_OBJECT
 public:
-    ElevationMetatilesPixmapItem(Map *map_): MetatilesPixmapItem(map_) {
+    ElevationMetatilesPixmapItem(Map *map_): MovementPermissionsPixmapItem(map_) {
         connect(map, SIGNAL(paintCollisionChanged(Map*)), this, SLOT(paintCollisionChanged(Map *)));
     }
     virtual void pick(uint elevation) {


### PR DESCRIPTION
This broke with the recent multi-block selection feature.  I didn't realize these were subclasses of the `MetatilesPixMapItem` class, so they were trying to use that feature.  To fix this, I created a new class call `MovementPermissionsPixmapItem`, and both inherit from it, since their selections behave identically.