### PR TITLE
Edit Map Connections

### DIFF
--- a/editor.cpp
+++ b/editor.cpp
@@ -611,7 +611,9 @@ void Editor::updateMirroredConnection(Connection* connection, QString originalDi
         return;
 
     static QMap<QString, QString> oppositeDirections = QMap<QString, QString>({
-        {"up", "down"}, {"right", "left"}, {"down", "up"}, {"left", "right"}});
+        {"up", "down"}, {"right", "left"},
+        {"down", "up"}, {"left", "right"},
+        {"dive", "emerge"},{"emerge", "dive"}});
     QString oppositeDirection = oppositeDirections.value(originalDirection);
 
     // Find the matching connection in the connected map.
@@ -698,16 +700,21 @@ void Editor::updateDiveEmergeMap(QString mapName, QString direction) {
         // Remove dive/emerge connection
         if (connection) {
             map->connections.removeOne(connection);
+            removeMirroredConnection(connection);
         }
     } else {
         if (!connection) {
             connection = new Connection;
             connection->direction = direction;
             connection->offset = "0";
+            connection->map_name = mapName;
             map->connections.append(connection);
+            updateMirroredConnection(connection, connection->direction, connection->map_name);
+        } else {
+            QString originalMapName = connection->map_name;
+            connection->map_name = mapName;
+            updateMirroredConnectionMap(connection, originalMapName);
         }
-
-        connection->map_name = mapName;
     }
 
     ui->label_NumConnections->setText(QString::number(map->connections.length()));

--- a/editor.cpp
+++ b/editor.cpp
@@ -276,6 +276,7 @@ void Editor::onConnectionItemSelected(ConnectionPixmapItem* connectionItem) {
     setConnectionEditControlValues(selected_connection_item->connection);
     ui->spinBox_ConnectionOffset->setMaximum(selected_connection_item->getMaxOffset());
     ui->spinBox_ConnectionOffset->setMinimum(selected_connection_item->getMinOffset());
+    onConnectionOffsetChanged(selected_connection_item->connection->offset.toInt());
 }
 
 void Editor::setSelectedConnectionFromMap(QString mapName) {
@@ -534,7 +535,7 @@ void Editor::updateConnectionOffset(int offset) {
     selected_connection_item->connection->offset = QString::number(offset);
     if (selected_connection_item->connection->direction == "up" || selected_connection_item->connection->direction == "down") {
         selected_connection_item->setX(selected_connection_item->initialX + (offset - selected_connection_item->initialOffset) * 16);
-    } else {
+    } else if (selected_connection_item->connection->direction == "left" || selected_connection_item->connection->direction == "right") {
         selected_connection_item->setY(selected_connection_item->initialY + (offset - selected_connection_item->initialOffset) * 16);
     }
     selected_connection_item->blockSignals(false);

--- a/editor.cpp
+++ b/editor.cpp
@@ -166,6 +166,11 @@ void Editor::showCurrentConnectionMap(QString curDirection) {
             scene->removeItem(connection_item);
             delete connection_item;
             connection_item = NULL;
+
+            if (map->connection_items.contains(curDirection)) {
+                delete map->connection_items.value(curDirection);
+                map->connection_items.remove(curDirection);
+            }
         }
 
         ui->comboBox_ConnectedMap->setCurrentText("");

--- a/editor.cpp
+++ b/editor.cpp
@@ -152,7 +152,6 @@ void Editor::showCurrentConnectionMap(QString curDirection) {
         connection_item->setY(y);
         connection_item->setZValue(21);
         scene->addItem(connection_item);
-        scene->setSceneRect(0, 0, pixmap.width() + map_item->pixmap().width(), pixmap.height() + map_item->pixmap().height());
 
         connect(connection_item, SIGNAL(connectionMoved(int)), this, SLOT(onConnectionOffsetChanged(int)));
         onConnectionOffsetChanged(connection->offset.toInt());
@@ -163,7 +162,6 @@ void Editor::showCurrentConnectionMap(QString curDirection) {
 
     if (!connectionExists) {
         if (connection_item) {
-            scene->removeItem(connection_item);
             delete connection_item;
             connection_item = NULL;
 

--- a/editor.cpp
+++ b/editor.cpp
@@ -254,11 +254,24 @@ void Editor::onConnectionItemSelected(ConnectionPixmapItem* connectionItem) {
         }
     }
     current_connection_edit_item = connectionItem;
-    current_connection_edit_item->setZValue(0);
     setConnectionEditControlsEnabled(true);
     setConnectionEditControlValues(current_connection_edit_item->connection);
     ui->spinBox_ConnectionOffset->setMaximum(current_connection_edit_item->getMaxOffset());
     ui->spinBox_ConnectionOffset->setMinimum(current_connection_edit_item->getMinOffset());
+}
+
+void Editor::setSelectedConnectionFromMap(QString mapName) {
+    // Search for the first connection that connects to the given map map.
+    for (ConnectionPixmapItem* item : connection_edit_items) {
+        if (item->connection->map_name == mapName) {
+            onConnectionItemSelected(item);
+            break;
+        }
+    }
+}
+
+void Editor::onConnectionItemDoubleClicked(ConnectionPixmapItem* connectionItem) {
+    emit loadMapRequested(connectionItem->connection->map_name, map->name);
 }
 
 void Editor::onConnectionDirectionChanged(QString newDirection) {
@@ -460,6 +473,7 @@ void Editor::createConnectionItem(Connection* connection, bool hide) {
     scene->addItem(connection_edit_item);
     connect(connection_edit_item, SIGNAL(connectionMoved(int)), this, SLOT(onConnectionOffsetChanged(int)));
     connect(connection_edit_item, SIGNAL(connectionItemSelected(ConnectionPixmapItem*)), this, SLOT(onConnectionItemSelected(ConnectionPixmapItem*)));
+    connect(connection_edit_item, SIGNAL(connectionItemDoubleClicked(ConnectionPixmapItem*)), this, SLOT(onConnectionItemDoubleClicked(ConnectionPixmapItem*)));
     connection_edit_items.append(connection_edit_item);
 }
 
@@ -745,6 +759,9 @@ QVariant ConnectionPixmapItem::itemChange(GraphicsItemChange change, const QVari
 }
 void ConnectionPixmapItem::mousePressEvent(QGraphicsSceneMouseEvent* event) {
     emit connectionItemSelected(this);
+}
+void ConnectionPixmapItem::mouseDoubleClickEvent(QGraphicsSceneMouseEvent*) {
+    emit connectionItemDoubleClicked(this);
 }
 
 void ElevationMetatilesPixmapItem::updateCurHoveredMetatile(QPointF pos) {

--- a/editor.cpp
+++ b/editor.cpp
@@ -38,6 +38,7 @@ void Editor::redo() {
 void Editor::setEditingMap() {
     current_view = map_item;
     if (map_item) {
+        displayMapConnections();
         map_item->draw();
         map_item->setVisible(true);
         map_item->setEnabled(true);
@@ -48,6 +49,10 @@ void Editor::setEditingMap() {
     }
     if (objects_group) {
         objects_group->setVisible(false);
+    }
+    if (connection_item) {
+        connection_item->setVisible(false);
+        connection_item->setEnabled(false);
     }
 }
 
@@ -62,6 +67,10 @@ void Editor::setEditingCollision() {
     }
     if (objects_group) {
         objects_group->setVisible(false);
+    }
+    if (connection_item) {
+        connection_item->setVisible(false);
+        connection_item->setEnabled(false);
     }
 }
 
@@ -78,6 +87,10 @@ void Editor::setEditingObjects() {
     if (collision_item) {
         collision_item->setVisible(false);
     }
+    if (connection_item) {
+        connection_item->setVisible(false);
+        connection_item->setEnabled(false);
+    }
 }
 
 void Editor::setEditingConnections(QString direction) {
@@ -85,7 +98,7 @@ void Editor::setEditingConnections(QString direction) {
     if (map_item) {
         map_item->draw();
         map_item->setVisible(true);
-        map_item->setEnabled(true);
+        map_item->setEnabled(false);
         ui->comboBox_ConnectedMap->blockSignals(true);
         ui->comboBox_ConnectedMap->clear();
         ui->comboBox_ConnectedMap->addItems(*project->mapNames);
@@ -304,6 +317,11 @@ DraggablePixmapItem *Editor::addMapObject(Event *event) {
 }
 
 void Editor::displayMapConnections() {
+    for (QString key : map->connection_items.keys()) {
+        scene->removeItem(map->connection_items.value(key));
+        delete map->connection_items.value(key);
+    }
+
     for (Connection *connection : map->connections) {
         if (connection->direction == "dive" || connection->direction == "emerge") {
             continue;

--- a/editor.cpp
+++ b/editor.cpp
@@ -409,6 +409,7 @@ void Editor::displayMapConnections() {
     for (ConnectionPixmapItem* item : connection_edit_items) {
         delete item;
     }
+    current_connection_edit_item = NULL;
     connection_edit_items.clear();
 
     for (Connection *connection : map->connections) {

--- a/editor.h
+++ b/editor.h
@@ -13,6 +13,7 @@
 class DraggablePixmapItem;
 class MapPixmapItem;
 class CollisionPixmapItem;
+class ConnectionPixmapItem;
 class MetatilesPixmapItem;
 class CollisionMetatilesPixmapItem;
 class ElevationMetatilesPixmapItem;
@@ -44,6 +45,10 @@ public:
     void setEditingMap();
     void setEditingCollision();
     void setEditingObjects();
+    void setEditingConnections(QString direction);
+    void showCurrentConnectionMap(QString curDirection);
+    void setConnectionsVisibility(bool visible);
+    void updateConnectionOffset(int offset);
 
     DraggablePixmapItem *addMapObject(Event *event);
     void selectMapObject(DraggablePixmapItem *object);
@@ -58,6 +63,7 @@ public:
     QGraphicsScene *scene = NULL;
     QGraphicsPixmapItem *current_view = NULL;
     MapPixmapItem *map_item = NULL;
+    ConnectionPixmapItem *connection_item = NULL;
     CollisionPixmapItem *collision_item = NULL;
     QGraphicsItemGroup *objects_group = NULL;
 
@@ -80,10 +86,12 @@ public:
 private slots:
     void mouseEvent_map(QGraphicsSceneMouseEvent *event, MapPixmapItem *item);
     void mouseEvent_collision(QGraphicsSceneMouseEvent *event, CollisionPixmapItem *item);
+    void onConnectionOffsetChanged(int newOffset);
 
 signals:
     void objectsChanged();
     void selectedObjectsChanged();
+    void connectionOffsetChanged(int newOffset);
 };
 
 
@@ -238,6 +246,33 @@ protected:
     void mousePressEvent(QGraphicsSceneMouseEvent*);
     void mouseMoveEvent(QGraphicsSceneMouseEvent*);
     void mouseReleaseEvent(QGraphicsSceneMouseEvent*);
+};
+
+class ConnectionPixmapItem : public QObject, public QGraphicsPixmapItem {
+    Q_OBJECT
+public:
+    ConnectionPixmapItem(QPixmap pixmap, Connection* connection, int x, int y): QGraphicsPixmapItem(pixmap) {
+        this->connection = connection;
+        setFlag(ItemIsMovable);
+        setFlag(ItemIsSelectable);
+        setFlag(ItemSendsGeometryChanges);
+        this->initialX = x;
+        this->initialY = y;
+        this->initialOffset = connection->offset.toInt();
+    }
+    Connection* connection;
+    int initialX;
+    int initialY;
+    int initialOffset;
+protected:
+    QVariant itemChange(GraphicsItemChange change, const QVariant &value);
+    void dragEnterEvent(QGraphicsSceneDragDropEvent *event) override;
+    void dragLeaveEvent(QGraphicsSceneDragDropEvent *event) override;
+    void dropEvent(QGraphicsSceneDragDropEvent *event) override;
+    void dragMoveEvent(QGraphicsSceneDragDropEvent *event) override;
+    void mousePressEvent(QGraphicsSceneMouseEvent*);
+signals:
+    void connectionMoved(int offset);
 };
 
 class MetatilesPixmapItem : public QObject, public QGraphicsPixmapItem {

--- a/editor.h
+++ b/editor.h
@@ -48,6 +48,7 @@ public:
     void setEditingObjects();
     void setEditingConnections();
     void setCurrentConnectionDirection(QString curDirection);
+    void updateCurrentConnectionDirection(QString curDirection);
     void setConnectionsVisibility(bool visible);
     void updateConnectionOffset(int offset);
     void setConnectionMap(QString mapName);
@@ -101,11 +102,17 @@ private:
     void populateConnectionMapPickers();
     void setDiveEmergeControls();
     void updateDiveEmergeMap(QString mapName, QString direction);
+    void onConnectionOffsetChanged(int newOffset);
+    void removeMirroredConnection(Connection*);
+    void updateMirroredConnectionOffset(Connection*);
+    void updateMirroredConnectionDirection(Connection*, QString);
+    void updateMirroredConnectionMap(Connection*, QString);
+    void updateMirroredConnection(Connection*, QString, QString, bool isDelete = false);
 
 private slots:
     void mouseEvent_map(QGraphicsSceneMouseEvent *event, MapPixmapItem *item);
     void mouseEvent_collision(QGraphicsSceneMouseEvent *event, CollisionPixmapItem *item);
-    void onConnectionOffsetChanged(int newOffset);
+    void onConnectionMoved(Connection*);
     void onConnectionItemSelected(ConnectionPixmapItem* connectionItem);
     void onConnectionItemDoubleClicked(ConnectionPixmapItem* connectionItem);
     void onConnectionDirectionChanged(QString newDirection);
@@ -310,7 +317,7 @@ protected:
 signals:
     void connectionItemSelected(ConnectionPixmapItem* connectionItem);
     void connectionItemDoubleClicked(ConnectionPixmapItem* connectionItem);
-    void connectionMoved(int offset);
+    void connectionMoved(Connection*);
 };
 
 class MetatilesPixmapItem : public QObject, public QGraphicsPixmapItem {

--- a/editor.h
+++ b/editor.h
@@ -51,6 +51,8 @@ public:
     void setConnectionsVisibility(bool visible);
     void updateConnectionOffset(int offset);
     void updateConnectionMap(QString mapName, QString direction);
+    void addNewConnection();
+    void removeCurrentConnection();
 
     DraggablePixmapItem *addMapObject(Event *event);
     void selectMapObject(DraggablePixmapItem *object);
@@ -92,6 +94,7 @@ private:
     void setBorderItemsVisible(bool, qreal = 1);
     void setConnectionEditControlValues(Connection*);
     void setConnectionEditControlsEnabled(bool);
+    void createConnectionItem(Connection* connection, bool hide);
 
 private slots:
     void mouseEvent_map(QGraphicsSceneMouseEvent *event, MapPixmapItem *item);

--- a/editor.h
+++ b/editor.h
@@ -50,7 +50,7 @@ public:
     void setCurrentConnectionDirection(QString curDirection);
     void setConnectionsVisibility(bool visible);
     void updateConnectionOffset(int offset);
-    void updateConnectionMap(QString mapName, QString direction);
+    void setConnectionMap(QString mapName);
     void addNewConnection();
     void removeCurrentConnection();
     void updateDiveMap(QString mapName);
@@ -70,7 +70,7 @@ public:
     QGraphicsScene *scene = NULL;
     QGraphicsPixmapItem *current_view = NULL;
     MapPixmapItem *map_item = NULL;
-    ConnectionPixmapItem* current_connection_edit_item = NULL;
+    ConnectionPixmapItem* selected_connection_item = NULL;
     QList<ConnectionPixmapItem*> connection_edit_items;
     CollisionPixmapItem *collision_item = NULL;
     QGraphicsItemGroup *objects_group = NULL;

--- a/editor.h
+++ b/editor.h
@@ -270,7 +270,7 @@ protected:
 class ConnectionPixmapItem : public QObject, public QGraphicsPixmapItem {
     Q_OBJECT
 public:
-    ConnectionPixmapItem(QPixmap pixmap, Connection* connection, int x, int y): QGraphicsPixmapItem(pixmap) {
+    ConnectionPixmapItem(QPixmap pixmap, Connection* connection, int x, int y, int baseMapWidth, int baseMapHeight): QGraphicsPixmapItem(pixmap) {
         this->basePixmap = pixmap;
         this->connection = connection;
         setFlag(ItemIsMovable);
@@ -278,6 +278,8 @@ public:
         this->initialX = x;
         this->initialY = y;
         this->initialOffset = connection->offset.toInt();
+        this->baseMapWidth = baseMapWidth;
+        this->baseMapHeight = baseMapHeight;
     }
     void render(qreal opacity = 1) {
         QPixmap newPixmap = basePixmap.copy(0, 0, basePixmap.width(), basePixmap.height());
@@ -289,11 +291,15 @@ public:
         }
         this->setPixmap(newPixmap);
     }
+    int getMinOffset();
+    int getMaxOffset();
     QPixmap basePixmap;
     Connection* connection;
     int initialX;
     int initialY;
     int initialOffset;
+    int baseMapWidth;
+    int baseMapHeight;
 protected:
     QVariant itemChange(GraphicsItemChange change, const QVariant &value);
     void mousePressEvent(QGraphicsSceneMouseEvent*);

--- a/editor.h
+++ b/editor.h
@@ -55,6 +55,7 @@ public:
     void removeCurrentConnection();
     void updateDiveMap(QString mapName);
     void updateEmergeMap(QString mapName);
+    void setSelectedConnectionFromMap(QString mapName);
 
     DraggablePixmapItem *addMapObject(Event *event);
     void selectMapObject(DraggablePixmapItem *object);
@@ -106,11 +107,13 @@ private slots:
     void mouseEvent_collision(QGraphicsSceneMouseEvent *event, CollisionPixmapItem *item);
     void onConnectionOffsetChanged(int newOffset);
     void onConnectionItemSelected(ConnectionPixmapItem* connectionItem);
+    void onConnectionItemDoubleClicked(ConnectionPixmapItem* connectionItem);
     void onConnectionDirectionChanged(QString newDirection);
 
 signals:
     void objectsChanged();
     void selectedObjectsChanged();
+    void loadMapRequested(QString, QString);
 };
 
 
@@ -303,8 +306,10 @@ public:
 protected:
     QVariant itemChange(GraphicsItemChange change, const QVariant &value);
     void mousePressEvent(QGraphicsSceneMouseEvent*);
+    void mouseDoubleClickEvent(QGraphicsSceneMouseEvent*);
 signals:
     void connectionItemSelected(ConnectionPixmapItem* connectionItem);
+    void connectionItemDoubleClicked(ConnectionPixmapItem* connectionItem);
     void connectionMoved(int offset);
 };
 

--- a/editor.h
+++ b/editor.h
@@ -9,6 +9,7 @@
 #include <QCheckBox>
 
 #include "project.h"
+#include "ui_mainwindow.h"
 
 class DraggablePixmapItem;
 class MapPixmapItem;
@@ -22,12 +23,12 @@ class Editor : public QObject
 {
     Q_OBJECT
 public:
-    Editor();
+    Editor(Ui::MainWindow* ui);
 public:
+    Ui::MainWindow* ui;
     QObject *parent = NULL;
     Project *project = NULL;
     Map *map = NULL;
-    QCheckBox *gridToggleCheckbox = NULL;
     void saveProject();
     void save();
     void undo();
@@ -49,6 +50,7 @@ public:
     void showCurrentConnectionMap(QString curDirection);
     void setConnectionsVisibility(bool visible);
     void updateConnectionOffset(int offset);
+    void updateConnectionMap(QString mapName, QString direction);
 
     DraggablePixmapItem *addMapObject(Event *event);
     void selectMapObject(DraggablePixmapItem *object);
@@ -91,7 +93,6 @@ private slots:
 signals:
     void objectsChanged();
     void selectedObjectsChanged();
-    void connectionOffsetChanged(int newOffset);
 };
 
 
@@ -254,7 +255,6 @@ public:
     ConnectionPixmapItem(QPixmap pixmap, Connection* connection, int x, int y): QGraphicsPixmapItem(pixmap) {
         this->connection = connection;
         setFlag(ItemIsMovable);
-        setFlag(ItemIsSelectable);
         setFlag(ItemSendsGeometryChanges);
         this->initialX = x;
         this->initialY = y;

--- a/editor.h
+++ b/editor.h
@@ -53,6 +53,8 @@ public:
     void updateConnectionMap(QString mapName, QString direction);
     void addNewConnection();
     void removeCurrentConnection();
+    void updateDiveMap(QString mapName);
+    void updateEmergeMap(QString mapName);
 
     DraggablePixmapItem *addMapObject(Event *event);
     void selectMapObject(DraggablePixmapItem *object);
@@ -95,6 +97,9 @@ private:
     void setConnectionEditControlValues(Connection*);
     void setConnectionEditControlsEnabled(bool);
     void createConnectionItem(Connection* connection, bool hide);
+    void populateConnectionMapPickers();
+    void setDiveEmergeControls();
+    void updateDiveEmergeMap(QString mapName, QString direction);
 
 private slots:
     void mouseEvent_map(QGraphicsSceneMouseEvent *event, MapPixmapItem *item);

--- a/graphicsview.cpp
+++ b/graphicsview.cpp
@@ -1,4 +1,5 @@
 #include "graphicsview.h"
+#include "editor.h"
 
 void GraphicsView::mousePressEvent(QMouseEvent *event) {
     QGraphicsView::mousePressEvent(event);

--- a/graphicsview.h
+++ b/graphicsview.h
@@ -4,7 +4,7 @@
 #include <QGraphicsView>
 #include <QMouseEvent>
 
-#include "editor.h"
+class Editor;
 
 /*
 class GraphicsView_Object : public QObject
@@ -26,7 +26,7 @@ public:
 
 public:
 //    GraphicsView_Object object;
-    Editor *editor = NULL;
+    Editor *editor;
 protected:
     void mousePressEvent(QMouseEvent *event);
     void mouseMoveEvent(QMouseEvent *event);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -775,7 +775,7 @@ void MainWindow::on_action_Export_Map_Image_triggered()
 
 void MainWindow::on_comboBox_ConnectionDirection_currentIndexChanged(const QString &direction)
 {
-    editor->setCurrentConnectionDirection(direction);
+    editor->updateCurrentConnectionDirection(direction);
 }
 
 void MainWindow::on_spinBox_ConnectionOffset_valueChanged(int offset)

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -26,11 +26,9 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->setupUi(this);
     new QShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_Z), this, SLOT(redo()));
 
-    editor = new Editor;
-    editor->gridToggleCheckbox = ui->checkBox_ToggleGrid;
+    editor = new Editor(ui);
     connect(editor, SIGNAL(objectsChanged()), this, SLOT(updateSelectedObjects()));
     connect(editor, SIGNAL(selectedObjectsChanged()), this, SLOT(updateSelectedObjects()));
-    connect(editor, SIGNAL(connectionOffsetChanged(int)), this, SLOT(onConnectionOffsetChanged(int)));
 
     on_toolButton_Paint_clicked();
 
@@ -776,9 +774,7 @@ void MainWindow::on_spinBox_ConnectionOffset_valueChanged(int offset)
     editor->updateConnectionOffset(offset);
 }
 
-void MainWindow::onConnectionOffsetChanged(int offset)
+void MainWindow::on_comboBox_ConnectedMap_currentTextChanged(const QString &mapName)
 {
-    ui->spinBox_ConnectionOffset->blockSignals(true);
-    ui->spinBox_ConnectionOffset->setValue(offset);
-    ui->spinBox_ConnectionOffset->blockSignals(false);
+    editor->updateConnectionMap(mapName, ui->comboBox_ConnectionDirection->currentText().toLower());
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -785,7 +785,7 @@ void MainWindow::on_spinBox_ConnectionOffset_valueChanged(int offset)
 
 void MainWindow::on_comboBox_ConnectedMap_currentTextChanged(const QString &mapName)
 {
-    editor->updateConnectionMap(mapName, ui->comboBox_ConnectionDirection->currentText().toLower());
+    editor->setConnectionMap(mapName);
 }
 
 void MainWindow::on_pushButton_AddConnection_clicked()

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -30,6 +30,7 @@ MainWindow::MainWindow(QWidget *parent) :
     editor->gridToggleCheckbox = ui->checkBox_ToggleGrid;
     connect(editor, SIGNAL(objectsChanged()), this, SLOT(updateSelectedObjects()));
     connect(editor, SIGNAL(selectedObjectsChanged()), this, SLOT(updateSelectedObjects()));
+    connect(editor, SIGNAL(connectionOffsetChanged(int)), this, SLOT(onConnectionOffsetChanged(int)));
 
     on_toolButton_Paint_clicked();
 
@@ -143,15 +144,7 @@ void MainWindow::setMap(QString map_name) {
     }
     editor->setMap(map_name);
 
-    if (ui->tabWidget->currentIndex() == 1) {
-        editor->setEditingObjects();
-    } else {
-        if (ui->tabWidget_2->currentIndex() == 1) {
-            editor->setEditingCollision();
-        } else {
-            editor->setEditingMap();
-        }
-    }
+    on_tabWidget_currentChanged(ui->tabWidget->currentIndex());
 
     ui->graphicsView_Map->setScene(editor->scene);
     ui->graphicsView_Map->setSceneRect(editor->scene->sceneRect());
@@ -161,6 +154,8 @@ void MainWindow::setMap(QString map_name) {
     ui->graphicsView_Objects_Map->setSceneRect(editor->scene->sceneRect());
     ui->graphicsView_Objects_Map->setFixedSize(editor->scene->width() + 2, editor->scene->height() + 2);
     ui->graphicsView_Objects_Map->editor = editor;
+
+    ui->graphicsView_Connections->setScene(editor->scene);
 
     ui->graphicsView_Metatiles->setScene(editor->scene_metatiles);
     //ui->graphicsView_Metatiles->setSceneRect(editor->scene_metatiles->sceneRect());
@@ -491,6 +486,8 @@ void MainWindow::on_tabWidget_currentChanged(int index)
         on_tabWidget_2_currentChanged(ui->tabWidget_2->currentIndex());
     } else if (index == 1) {
         editor->setEditingObjects();
+    } else if (index == 3) {
+        editor->setEditingConnections(ui->comboBox_ConnectionDirection->currentText().toLower());
     }
 }
 
@@ -767,4 +764,21 @@ void MainWindow::on_action_Export_Map_Image_triggered()
     if (!filepath.isEmpty()) {
         editor->map_item->pixmap().save(filepath);
     }
+}
+
+void MainWindow::on_comboBox_ConnectionDirection_currentIndexChanged(const QString &direction)
+{
+    editor->showCurrentConnectionMap(direction.toLower());
+}
+
+void MainWindow::on_spinBox_ConnectionOffset_valueChanged(int offset)
+{
+    editor->updateConnectionOffset(offset);
+}
+
+void MainWindow::onConnectionOffsetChanged(int offset)
+{
+    ui->spinBox_ConnectionOffset->blockSignals(true);
+    ui->spinBox_ConnectionOffset->setValue(offset);
+    ui->spinBox_ConnectionOffset->blockSignals(false);
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -154,6 +154,8 @@ void MainWindow::setMap(QString map_name) {
     ui->graphicsView_Objects_Map->editor = editor;
 
     ui->graphicsView_Connections->setScene(editor->scene);
+    ui->graphicsView_Connections->setSceneRect(editor->scene->sceneRect());
+    ui->graphicsView_Connections->setFixedSize(editor->scene->width() + 2, editor->scene->height() + 2);
 
     ui->graphicsView_Metatiles->setScene(editor->scene_metatiles);
     //ui->graphicsView_Metatiles->setSceneRect(editor->scene_metatiles->sceneRect());

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -780,3 +780,13 @@ void MainWindow::on_comboBox_ConnectedMap_currentTextChanged(const QString &mapN
 {
     editor->updateConnectionMap(mapName, ui->comboBox_ConnectionDirection->currentText().toLower());
 }
+
+void MainWindow::on_pushButton_AddConnection_clicked()
+{
+    editor->addNewConnection();
+}
+
+void MainWindow::on_pushButton_RemoveConnection_clicked()
+{
+    editor->removeCurrentConnection();
+}

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -289,6 +289,7 @@ void MainWindow::loadDataStructures() {
     project->readItemNames();
     project->readFlagNames();
     project->readVarNames();
+    project->readMapsWithConnections();
 }
 
 void MainWindow::populateMapList() {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -487,7 +487,7 @@ void MainWindow::on_tabWidget_currentChanged(int index)
     } else if (index == 1) {
         editor->setEditingObjects();
     } else if (index == 3) {
-        editor->setEditingConnections(ui->comboBox_ConnectionDirection->currentText().toLower());
+        editor->setEditingConnections();
     }
 }
 
@@ -768,7 +768,7 @@ void MainWindow::on_action_Export_Map_Image_triggered()
 
 void MainWindow::on_comboBox_ConnectionDirection_currentIndexChanged(const QString &direction)
 {
-    editor->showCurrentConnectionMap(direction.toLower());
+    editor->setCurrentConnectionDirection(direction);
 }
 
 void MainWindow::on_spinBox_ConnectionOffset_valueChanged(int offset)

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -29,6 +29,7 @@ MainWindow::MainWindow(QWidget *parent) :
     editor = new Editor(ui);
     connect(editor, SIGNAL(objectsChanged()), this, SLOT(updateSelectedObjects()));
     connect(editor, SIGNAL(selectedObjectsChanged()), this, SLOT(updateSelectedObjects()));
+    connect(editor, SIGNAL(loadMapRequested(QString, QString)), this, SLOT(onLoadMapRequested(QString, QString)));
 
     on_toolButton_Paint_clicked();
 
@@ -752,6 +753,11 @@ void MainWindow::checkToolButtons() {
     ui->toolButton_Select->setChecked(editor->map_edit_mode == "select");
     ui->toolButton_Fill->setChecked(editor->map_edit_mode == "fill");
     ui->toolButton_Dropper->setChecked(editor->map_edit_mode == "pick");
+}
+
+void MainWindow::onLoadMapRequested(QString mapName, QString fromMapName) {
+    setMap(mapName);
+    editor->setSelectedConnectionFromMap(fromMapName);
 }
 
 void MainWindow::onMapChanged(Map *map) {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -790,3 +790,13 @@ void MainWindow::on_pushButton_RemoveConnection_clicked()
 {
     editor->removeCurrentConnection();
 }
+
+void MainWindow::on_comboBox_DiveMap_currentTextChanged(const QString &mapName)
+{
+    editor->updateDiveMap(mapName);
+}
+
+void MainWindow::on_comboBox_EmergeMap_currentTextChanged(const QString &mapName)
+{
+    editor->updateEmergeMap(mapName);
+}

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -80,6 +80,10 @@ private slots:
 
     void on_comboBox_ConnectedMap_currentTextChanged(const QString &mapName);
 
+    void on_pushButton_AddConnection_clicked();
+
+    void on_pushButton_RemoveConnection_clicked();
+
 private:
     Ui::MainWindow *ui;
     QStandardItemModel *mapListModel;

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -78,7 +78,7 @@ private slots:
 
     void on_spinBox_ConnectionOffset_valueChanged(int offset);
 
-    void onConnectionOffsetChanged(int offset);
+    void on_comboBox_ConnectedMap_currentTextChanged(const QString &mapName);
 
 private:
     Ui::MainWindow *ui;

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -74,6 +74,12 @@ private slots:
 
     void on_action_Export_Map_Image_triggered();
 
+    void on_comboBox_ConnectionDirection_currentIndexChanged(const QString &arg1);
+
+    void on_spinBox_ConnectionOffset_valueChanged(int offset);
+
+    void onConnectionOffsetChanged(int offset);
+
 private:
     Ui::MainWindow *ui;
     QStandardItemModel *mapListModel;

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -36,6 +36,7 @@ private slots:
     void undo();
     void redo();
 
+    void onLoadMapRequested(QString, QString);
     void onMapChanged(Map *map);
 
     void on_action_Save_triggered();

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -84,6 +84,10 @@ private slots:
 
     void on_pushButton_RemoveConnection_clicked();
 
+    void on_comboBox_DiveMap_currentTextChanged(const QString &mapName);
+
+    void on_comboBox_EmergeMap_currentTextChanged(const QString &mapName);
+
 private:
     Ui::MainWindow *ui;
     QStandardItemModel *mapListModel;

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -1199,6 +1199,265 @@
          </widget>
         </widget>
        </widget>
+       <widget class="QWidget" name="tab_Connections">
+        <attribute name="title">
+         <string>Connections</string>
+        </attribute>
+        <layout class="QGridLayout" name="gridLayout_12">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item row="3" column="0">
+          <widget class="QFrame" name="gridFrame">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="frameShape">
+            <enum>QFrame::StyledPanel</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Raised</enum>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_11">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <item row="0" column="0">
+             <widget class="QFrame" name="horizontalFrame">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>32</height>
+               </size>
+              </property>
+              <property name="frameShape">
+               <enum>QFrame::StyledPanel</enum>
+              </property>
+              <property name="frameShadow">
+               <enum>QFrame::Raised</enum>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0,0,0,0">
+               <property name="spacing">
+                <number>4</number>
+               </property>
+               <property name="leftMargin">
+                <number>4</number>
+               </property>
+               <property name="topMargin">
+                <number>4</number>
+               </property>
+               <property name="rightMargin">
+                <number>4</number>
+               </property>
+               <property name="bottomMargin">
+                <number>4</number>
+               </property>
+               <item>
+                <widget class="QComboBox" name="comboBox_ConnectionDirection">
+                 <item>
+                  <property name="text">
+                   <string>North</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>East</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>South</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>West</string>
+                  </property>
+                 </item>
+                </widget>
+               </item>
+               <item>
+                <spacer name="horizontalSpacer_2">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeType">
+                  <enum>QSizePolicy::Fixed</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="QLabel" name="label_11">
+                 <property name="text">
+                  <string>Map</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QComboBox" name="comboBox_ConnectedMap">
+                 <property name="editable">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="horizontalSpacer_6">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QFrame" name="gridFrame">
+              <property name="frameShape">
+               <enum>QFrame::StyledPanel</enum>
+              </property>
+              <property name="frameShadow">
+               <enum>QFrame::Raised</enum>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_13">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <property name="spacing">
+                <number>0</number>
+               </property>
+               <item row="0" column="0">
+                <widget class="QScrollArea" name="scrollArea_5">
+                 <property name="widgetResizable">
+                  <bool>true</bool>
+                 </property>
+                 <widget class="QWidget" name="scrollAreaWidgetContents_3">
+                  <property name="geometry">
+                   <rect>
+                    <x>0</x>
+                    <y>0</y>
+                    <width>826</width>
+                    <height>621</height>
+                   </rect>
+                  </property>
+                  <layout class="QGridLayout" name="gridLayout_15">
+                   <item row="1" column="1">
+                    <widget class="QGraphicsView" name="graphicsView"/>
+                   </item>
+                   <item row="0" column="1">
+                    <spacer name="verticalSpacer">
+                     <property name="orientation">
+                      <enum>Qt::Vertical</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>20</width>
+                       <height>40</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                   <item row="2" column="1">
+                    <spacer name="verticalSpacer_2">
+                     <property name="orientation">
+                      <enum>Qt::Vertical</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>20</width>
+                       <height>40</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                   <item row="1" column="0">
+                    <spacer name="horizontalSpacer_7">
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>40</width>
+                       <height>20</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                   <item row="1" column="2">
+                    <spacer name="horizontalSpacer_8">
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>40</width>
+                       <height>20</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                  </layout>
+                 </widget>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </widget>
       </widget>
      </widget>
     </item>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -60,7 +60,7 @@
         </sizepolicy>
        </property>
        <property name="currentIndex">
-        <number>0</number>
+        <number>3</number>
        </property>
        <property name="tabsClosable">
         <bool>false</bool>
@@ -1266,7 +1266,7 @@
               <property name="frameShadow">
                <enum>QFrame::Raised</enum>
               </property>
-              <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0,0,0,0">
+              <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0,0,0,0,0,0">
                <property name="spacing">
                 <number>4</number>
                </property>
@@ -1286,22 +1286,22 @@
                 <widget class="QComboBox" name="comboBox_ConnectionDirection">
                  <item>
                   <property name="text">
-                   <string>North</string>
+                   <string>Up</string>
                   </property>
                  </item>
                  <item>
                   <property name="text">
-                   <string>East</string>
+                   <string>Right</string>
                   </property>
                  </item>
                  <item>
                   <property name="text">
-                   <string>South</string>
+                   <string>Down</string>
                   </property>
                  </item>
                  <item>
                   <property name="text">
-                   <string>West</string>
+                   <string>Left</string>
                   </property>
                  </item>
                 </widget>
@@ -1333,6 +1333,20 @@
                 <widget class="QComboBox" name="comboBox_ConnectedMap">
                  <property name="editable">
                   <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="label_12">
+                 <property name="text">
+                  <string>Offset</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QSpinBox" name="spinBox_ConnectionOffset">
+                 <property name="minimum">
+                  <number>-99</number>
                  </property>
                 </widget>
                </item>
@@ -1377,78 +1391,7 @@
                 <number>0</number>
                </property>
                <item row="0" column="0">
-                <widget class="QScrollArea" name="scrollArea_5">
-                 <property name="widgetResizable">
-                  <bool>true</bool>
-                 </property>
-                 <widget class="QWidget" name="scrollAreaWidgetContents_3">
-                  <property name="geometry">
-                   <rect>
-                    <x>0</x>
-                    <y>0</y>
-                    <width>826</width>
-                    <height>621</height>
-                   </rect>
-                  </property>
-                  <layout class="QGridLayout" name="gridLayout_15">
-                   <item row="1" column="1">
-                    <widget class="QGraphicsView" name="graphicsView"/>
-                   </item>
-                   <item row="0" column="1">
-                    <spacer name="verticalSpacer">
-                     <property name="orientation">
-                      <enum>Qt::Vertical</enum>
-                     </property>
-                     <property name="sizeHint" stdset="0">
-                      <size>
-                       <width>20</width>
-                       <height>40</height>
-                      </size>
-                     </property>
-                    </spacer>
-                   </item>
-                   <item row="2" column="1">
-                    <spacer name="verticalSpacer_2">
-                     <property name="orientation">
-                      <enum>Qt::Vertical</enum>
-                     </property>
-                     <property name="sizeHint" stdset="0">
-                      <size>
-                       <width>20</width>
-                       <height>40</height>
-                      </size>
-                     </property>
-                    </spacer>
-                   </item>
-                   <item row="1" column="0">
-                    <spacer name="horizontalSpacer_7">
-                     <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
-                     </property>
-                     <property name="sizeHint" stdset="0">
-                      <size>
-                       <width>40</width>
-                       <height>20</height>
-                      </size>
-                     </property>
-                    </spacer>
-                   </item>
-                   <item row="1" column="2">
-                    <spacer name="horizontalSpacer_8">
-                     <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
-                     </property>
-                     <property name="sizeHint" stdset="0">
-                      <size>
-                       <width>40</width>
-                       <height>20</height>
-                      </size>
-                     </property>
-                    </spacer>
-                   </item>
-                  </layout>
-                 </widget>
-                </widget>
+                <widget class="QGraphicsView" name="graphicsView_Connections"/>
                </item>
               </layout>
              </widget>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -1286,22 +1286,22 @@
                 <widget class="QComboBox" name="comboBox_ConnectionDirection">
                  <item>
                   <property name="text">
-                   <string>Up</string>
+                   <string>up</string>
                   </property>
                  </item>
                  <item>
                   <property name="text">
-                   <string>Right</string>
+                   <string>right</string>
                   </property>
                  </item>
                  <item>
                   <property name="text">
-                   <string>Down</string>
+                   <string>down</string>
                   </property>
                  </item>
                  <item>
                   <property name="text">
-                   <string>Left</string>
+                   <string>left</string>
                   </property>
                  </item>
                 </widget>
@@ -1346,7 +1346,10 @@
                <item>
                 <widget class="QSpinBox" name="spinBox_ConnectionOffset">
                  <property name="minimum">
-                  <number>-99</number>
+                  <number>-999</number>
+                 </property>
+                 <property name="maximum">
+                  <number>999</number>
                  </property>
                 </widget>
                </item>
@@ -1412,7 +1415,17 @@
                   </property>
                   <layout class="QGridLayout" name="gridLayout_14">
                    <item row="1" column="1">
-                    <widget class="QGraphicsView" name="graphicsView_Connections"/>
+                    <widget class="QGraphicsView" name="graphicsView_Connections">
+                     <property name="backgroundBrush">
+                      <brush brushstyle="SolidPattern">
+                       <color alpha="255">
+                        <red>0</red>
+                        <green>0</green>
+                        <blue>0</blue>
+                       </color>
+                      </brush>
+                     </property>
+                    </widget>
                    </item>
                    <item row="1" column="0">
                     <spacer name="horizontalSpacer_7">

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -60,7 +60,7 @@
         </sizepolicy>
        </property>
        <property name="currentIndex">
-        <number>0</number>
+        <number>3</number>
        </property>
        <property name="tabsClosable">
         <bool>false</bool>
@@ -1246,7 +1246,7 @@
             <property name="spacing">
              <number>0</number>
             </property>
-            <item row="0" column="0">
+            <item row="1" column="0">
              <widget class="QFrame" name="horizontalFrame">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -1369,7 +1369,7 @@
               </layout>
              </widget>
             </item>
-            <item row="1" column="0">
+            <item row="2" column="0">
              <widget class="QFrame" name="gridFrame">
               <property name="frameShape">
                <enum>QFrame::StyledPanel</enum>
@@ -1410,7 +1410,7 @@
                     <x>0</x>
                     <y>0</y>
                     <width>826</width>
-                    <height>621</height>
+                    <height>587</height>
                    </rect>
                   </property>
                   <layout class="QGridLayout" name="gridLayout_14">
@@ -1482,6 +1482,102 @@
                   </layout>
                  </widget>
                 </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QFrame" name="horizontalFrame">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>32</height>
+               </size>
+              </property>
+              <property name="frameShape">
+               <enum>QFrame::StyledPanel</enum>
+              </property>
+              <property name="frameShadow">
+               <enum>QFrame::Raised</enum>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_4">
+               <property name="spacing">
+                <number>4</number>
+               </property>
+               <property name="leftMargin">
+                <number>4</number>
+               </property>
+               <property name="topMargin">
+                <number>4</number>
+               </property>
+               <property name="rightMargin">
+                <number>4</number>
+               </property>
+               <property name="bottomMargin">
+                <number>4</number>
+               </property>
+               <item>
+                <widget class="QPushButton" name="pushButton_AddConnection">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string/>
+                 </property>
+                 <property name="icon">
+                  <iconset>
+                   <activeon>:/icons/add.ico</activeon>
+                  </iconset>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="pushButton_RemoveConnection">
+                 <property name="text">
+                  <string/>
+                 </property>
+                 <property name="icon">
+                  <iconset>
+                   <activeon>:/icons/delete.ico</activeon>
+                  </iconset>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="label_13">
+                 <property name="text">
+                  <string>Number of Connections:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="label_NumConnections">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="horizontalSpacer_9">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
                </item>
               </layout>
              </widget>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -1327,6 +1327,38 @@
                 </widget>
                </item>
                <item>
+                <spacer name="horizontalSpacer_11">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeType">
+                  <enum>QSizePolicy::Maximum</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="checkBox_MirrorConnections">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Mirror</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <spacer name="horizontalSpacer_9">
                  <property name="orientation">
                   <enum>Qt::Horizontal</enum>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -60,7 +60,7 @@
         </sizepolicy>
        </property>
        <property name="currentIndex">
-        <number>3</number>
+        <number>0</number>
        </property>
        <property name="tabsClosable">
         <bool>false</bool>
@@ -1266,6 +1266,102 @@
               <property name="frameShadow">
                <enum>QFrame::Raised</enum>
               </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_4">
+               <property name="spacing">
+                <number>4</number>
+               </property>
+               <property name="leftMargin">
+                <number>4</number>
+               </property>
+               <property name="topMargin">
+                <number>4</number>
+               </property>
+               <property name="rightMargin">
+                <number>4</number>
+               </property>
+               <property name="bottomMargin">
+                <number>4</number>
+               </property>
+               <item>
+                <widget class="QPushButton" name="pushButton_AddConnection">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string/>
+                 </property>
+                 <property name="icon">
+                  <iconset>
+                   <activeon>:/icons/add.ico</activeon>
+                  </iconset>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="pushButton_RemoveConnection">
+                 <property name="text">
+                  <string/>
+                 </property>
+                 <property name="icon">
+                  <iconset>
+                   <activeon>:/icons/delete.ico</activeon>
+                  </iconset>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="label_13">
+                 <property name="text">
+                  <string>Number of Connections:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="label_NumConnections">
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="horizontalSpacer_9">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QFrame" name="horizontalFrame">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>32</height>
+               </size>
+              </property>
+              <property name="frameShape">
+               <enum>QFrame::StyledPanel</enum>
+              </property>
+              <property name="frameShadow">
+               <enum>QFrame::Raised</enum>
+              </property>
               <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0,0,0,0,0,0">
                <property name="spacing">
                 <number>4</number>
@@ -1369,7 +1465,7 @@
               </layout>
              </widget>
             </item>
-            <item row="2" column="0">
+            <item row="3" column="0">
              <widget class="QFrame" name="gridFrame">
               <property name="frameShape">
                <enum>QFrame::StyledPanel</enum>
@@ -1393,7 +1489,7 @@
                <property name="spacing">
                 <number>0</number>
                </property>
-               <item row="0" column="0">
+               <item row="1" column="0">
                 <widget class="QScrollArea" name="scrollArea_5">
                  <property name="sizePolicy">
                   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -1410,10 +1506,49 @@
                     <x>0</x>
                     <y>0</y>
                     <width>826</width>
-                    <height>587</height>
+                    <height>557</height>
                    </rect>
                   </property>
                   <layout class="QGridLayout" name="gridLayout_14">
+                   <item row="1" column="2">
+                    <spacer name="horizontalSpacer_8">
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>40</width>
+                       <height>20</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                   <item row="2" column="1">
+                    <spacer name="verticalSpacer_2">
+                     <property name="orientation">
+                      <enum>Qt::Vertical</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>20</width>
+                       <height>40</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                   <item row="0" column="1">
+                    <spacer name="verticalSpacer">
+                     <property name="orientation">
+                      <enum>Qt::Vertical</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>20</width>
+                       <height>40</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
                    <item row="1" column="1">
                     <widget class="QGraphicsView" name="graphicsView_Connections">
                      <property name="backgroundBrush">
@@ -1440,144 +1575,83 @@
                      </property>
                     </spacer>
                    </item>
-                   <item row="1" column="2">
-                    <spacer name="horizontalSpacer_8">
-                     <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
-                     </property>
-                     <property name="sizeHint" stdset="0">
-                      <size>
-                       <width>40</width>
-                       <height>20</height>
-                      </size>
-                     </property>
-                    </spacer>
-                   </item>
-                   <item row="0" column="1">
-                    <spacer name="verticalSpacer">
-                     <property name="orientation">
-                      <enum>Qt::Vertical</enum>
-                     </property>
-                     <property name="sizeHint" stdset="0">
-                      <size>
-                       <width>20</width>
-                       <height>40</height>
-                      </size>
-                     </property>
-                    </spacer>
-                   </item>
-                   <item row="2" column="1">
-                    <spacer name="verticalSpacer_2">
-                     <property name="orientation">
-                      <enum>Qt::Vertical</enum>
-                     </property>
-                     <property name="sizeHint" stdset="0">
-                      <size>
-                       <width>20</width>
-                       <height>40</height>
-                      </size>
-                     </property>
-                    </spacer>
-                   </item>
                   </layout>
                  </widget>
                 </widget>
                </item>
-              </layout>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QFrame" name="horizontalFrame">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>32</height>
-               </size>
-              </property>
-              <property name="frameShape">
-               <enum>QFrame::StyledPanel</enum>
-              </property>
-              <property name="frameShadow">
-               <enum>QFrame::Raised</enum>
-              </property>
-              <layout class="QHBoxLayout" name="horizontalLayout_4">
-               <property name="spacing">
-                <number>4</number>
-               </property>
-               <property name="leftMargin">
-                <number>4</number>
-               </property>
-               <property name="topMargin">
-                <number>4</number>
-               </property>
-               <property name="rightMargin">
-                <number>4</number>
-               </property>
-               <property name="bottomMargin">
-                <number>4</number>
-               </property>
-               <item>
-                <widget class="QPushButton" name="pushButton_AddConnection">
+               <item row="0" column="0">
+                <widget class="QFrame" name="horizontalFrame">
                  <property name="sizePolicy">
-                  <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
                    <horstretch>0</horstretch>
                    <verstretch>0</verstretch>
                   </sizepolicy>
                  </property>
-                 <property name="text">
-                  <string/>
+                 <property name="frameShape">
+                  <enum>QFrame::StyledPanel</enum>
                  </property>
-                 <property name="icon">
-                  <iconset>
-                   <activeon>:/icons/add.ico</activeon>
-                  </iconset>
+                 <property name="frameShadow">
+                  <enum>QFrame::Raised</enum>
                  </property>
+                 <layout class="QHBoxLayout" name="horizontalLayout_6">
+                  <property name="spacing">
+                   <number>4</number>
+                  </property>
+                  <property name="leftMargin">
+                   <number>4</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>4</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>4</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>4</number>
+                  </property>
+                  <item>
+                   <widget class="QLabel" name="label_14">
+                    <property name="text">
+                     <string>Dive Map</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QComboBox" name="comboBox_DiveMap">
+                    <property name="editable">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QLabel" name="label_15">
+                    <property name="text">
+                     <string>Emerge Map</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QComboBox" name="comboBox_EmergeMap">
+                    <property name="editable">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="horizontalSpacer_10">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
                 </widget>
-               </item>
-               <item>
-                <widget class="QPushButton" name="pushButton_RemoveConnection">
-                 <property name="text">
-                  <string/>
-                 </property>
-                 <property name="icon">
-                  <iconset>
-                   <activeon>:/icons/delete.ico</activeon>
-                  </iconset>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="label_13">
-                 <property name="text">
-                  <string>Number of Connections:</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="label_NumConnections">
-                 <property name="text">
-                  <string/>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <spacer name="horizontalSpacer_9">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
                </item>
               </layout>
              </widget>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -60,7 +60,7 @@
         </sizepolicy>
        </property>
        <property name="currentIndex">
-        <number>3</number>
+        <number>0</number>
        </property>
        <property name="tabsClosable">
         <bool>false</bool>
@@ -1391,7 +1391,84 @@
                 <number>0</number>
                </property>
                <item row="0" column="0">
-                <widget class="QGraphicsView" name="graphicsView_Connections"/>
+                <widget class="QScrollArea" name="scrollArea_5">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                   <horstretch>1</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="widgetResizable">
+                  <bool>true</bool>
+                 </property>
+                 <widget class="QWidget" name="scrollAreaWidgetContents_3">
+                  <property name="geometry">
+                   <rect>
+                    <x>0</x>
+                    <y>0</y>
+                    <width>826</width>
+                    <height>621</height>
+                   </rect>
+                  </property>
+                  <layout class="QGridLayout" name="gridLayout_14">
+                   <item row="1" column="1">
+                    <widget class="QGraphicsView" name="graphicsView_Connections"/>
+                   </item>
+                   <item row="1" column="0">
+                    <spacer name="horizontalSpacer_7">
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>40</width>
+                       <height>20</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                   <item row="1" column="2">
+                    <spacer name="horizontalSpacer_8">
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>40</width>
+                       <height>20</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                   <item row="0" column="1">
+                    <spacer name="verticalSpacer">
+                     <property name="orientation">
+                      <enum>Qt::Vertical</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>20</width>
+                       <height>40</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                   <item row="2" column="1">
+                    <spacer name="verticalSpacer_2">
+                     <property name="orientation">
+                      <enum>Qt::Vertical</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>20</width>
+                       <height>40</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                  </layout>
+                 </widget>
+                </widget>
                </item>
               </layout>
              </widget>

--- a/map.h
+++ b/map.h
@@ -180,7 +180,7 @@ public:
     QMap<QString, QList<Event*>> events;
 
     QList<Connection*> connections;
-    QMap<QString, QGraphicsPixmapItem*> connection_items;
+    QList<QGraphicsPixmapItem*> connection_items;
     QPixmap renderConnection(Connection);
 
     QImage border_image;

--- a/map.h
+++ b/map.h
@@ -8,6 +8,7 @@
 #include <QPixmap>
 #include <QObject>
 #include <QDebug>
+#include <QGraphicsPixmapItem>
 
 
 template <typename T>
@@ -179,6 +180,7 @@ public:
     QMap<QString, QList<Event*>> events;
 
     QList<Connection*> connections;
+    QMap<QString, QGraphicsPixmapItem*> connection_items;
     QPixmap renderConnection(Connection);
 
     QImage border_image;

--- a/parseutil.h
+++ b/parseutil.h
@@ -3,6 +3,7 @@
 
 #include <QString>
 #include <QList>
+#include <QMap>
 
 enum TokenType {
     Number,

--- a/project.cpp
+++ b/project.cpp
@@ -210,6 +210,30 @@ void Project::saveMapHeader(Map *map) {
     saveTextFile(header_path, text);
 }
 
+void Project::saveMapConnections(Map *map) {
+    QString connections_path = root + "/data/maps/" + map->name + "/connections.inc";
+    QString connectionsListLabel = QString("%1_MapConnectionsList").arg(map->name);
+    int numValidConnections = 0;
+    QString text = "";
+    text += QString("%1::\n").arg(connectionsListLabel);
+    for (Connection* connection : map->connections) {
+        if (mapNamesToMapConstants->contains(connection->map_name)) {
+            text += QString("\tconnection %1, %2, %3\n")
+                    .arg(connection->direction)
+                    .arg(connection->offset)
+                    .arg(mapNamesToMapConstants->value(connection->map_name));
+            numValidConnections++;
+        } else {
+            qDebug() << QString("Failed to write map connection. %1 not a valid map name").arg(connection->map_name);
+        }
+    }
+    text += QString("\n");
+    text += QString("%1::\n").arg(map->connections_label);
+    text += QString("\t.4byte %1\n").arg(numValidConnections);
+    text += QString("\t.4byte %1\n").arg(connectionsListLabel);
+    saveTextFile(connections_path, text);
+}
+
 void Project::readMapAttributesTable() {
     int curMapIndex = 1;
     QString attributesText = readTextFile(getMapAttributesTableFilepath());
@@ -680,6 +704,7 @@ void Project::saveMap(Map *map) {
 
     saveMapBorder(map);
     saveMapHeader(map);
+    saveMapConnections(map);
     saveBlockdata(map);
     saveMapEvents(map);
 

--- a/project.cpp
+++ b/project.cpp
@@ -39,7 +39,8 @@ Map* Project::loadMap(QString map_name) {
     Map *map;
     if (map_cache->contains(map_name)) {
         map = map_cache->value(map_name);
-        if (map->hasUnsavedChanges()) {
+        // TODO: uncomment when undo/redo history is fully implemented for all actions.
+        if (true/*map->hasUnsavedChanges()*/) {
             return map;
         }
     } else {
@@ -1260,7 +1261,6 @@ void Project::loadObjectPixmaps(QList<Event*> objects) {
         }
 
         if (event_type == "object") {
-
             int sprite_id = constants.value(object->get("sprite"));
 
             QString info_label = pointers.value(sprite_id).replace("&", "");

--- a/project.cpp
+++ b/project.cpp
@@ -67,6 +67,7 @@ void Project::loadMapConnections(Map *map) {
     }
 
     map->connections.clear();
+    map->connection_items.clear();
     if (!map->connections_label.isNull()) {
         QString path = root + QString("/data/maps/%1/connections.inc").arg(map->name);
         QString text = readTextFile(path);

--- a/project.cpp
+++ b/project.cpp
@@ -740,7 +740,9 @@ void Project::saveMap(Map *map) {
 }
 
 void Project::updateMapAttributes(Map* map) {
-    mapAttributesTableMaster.insert(map->index.toInt(nullptr, 0), map->name);
+    if (!mapAttributesTableMaster.contains(map->index.toInt())) {
+        mapAttributesTableMaster.insert(map->index.toInt(), map->name);
+    }
 
     // Deep copy
     QMap<QString, QString> attrs = mapAttributes.value(map->name);

--- a/project.cpp
+++ b/project.cpp
@@ -197,7 +197,14 @@ void Project::saveMapHeader(Map *map) {
     text += QString("\t.4byte %1\n").arg(map->attributes_label);
     text += QString("\t.4byte %1\n").arg(map->events_label);
     text += QString("\t.4byte %1\n").arg(map->scripts_label);
+
+    if (map->connections.length() == 0) {
+        map->connections_label = "0x0";
+    } else {
+        map->connections_label = QString("%1_MapConnections").arg(map->name);
+    }
     text += QString("\t.4byte %1\n").arg(map->connections_label);
+
     text += QString("\t.2byte %1\n").arg(map->song);
     text += QString("\t.2byte %1\n").arg(map->index);
     text += QString("\t.byte %1\n").arg(map->location);
@@ -211,27 +218,45 @@ void Project::saveMapHeader(Map *map) {
 }
 
 void Project::saveMapConnections(Map *map) {
-    QString connections_path = root + "/data/maps/" + map->name + "/connections.inc";
-    QString connectionsListLabel = QString("%1_MapConnectionsList").arg(map->name);
-    int numValidConnections = 0;
-    QString text = "";
-    text += QString("%1::\n").arg(connectionsListLabel);
-    for (Connection* connection : map->connections) {
-        if (mapNamesToMapConstants->contains(connection->map_name)) {
-            text += QString("\tconnection %1, %2, %3\n")
-                    .arg(connection->direction)
-                    .arg(connection->offset)
-                    .arg(mapNamesToMapConstants->value(connection->map_name));
-            numValidConnections++;
-        } else {
-            qDebug() << QString("Failed to write map connection. %1 not a valid map name").arg(connection->map_name);
+    QString path = root + "/data/maps/" + map->name + "/connections.inc";
+    if (map->connections.length() > 0) {
+        QString text = "";
+        QString connectionsListLabel = QString("%1_MapConnectionsList").arg(map->name);
+        int numValidConnections = 0;
+        text += QString("%1::\n").arg(connectionsListLabel);
+        for (Connection* connection : map->connections) {
+            if (mapNamesToMapConstants->contains(connection->map_name)) {
+                text += QString("\tconnection %1, %2, %3\n")
+                        .arg(connection->direction)
+                        .arg(connection->offset)
+                        .arg(mapNamesToMapConstants->value(connection->map_name));
+                numValidConnections++;
+            } else {
+                qDebug() << QString("Failed to write map connection. %1 not a valid map name").arg(connection->map_name);
+            }
+        }
+        text += QString("\n");
+        text += QString("%1::\n").arg(map->connections_label);
+        text += QString("\t.4byte %1\n").arg(numValidConnections);
+        text += QString("\t.4byte %1\n").arg(connectionsListLabel);
+        saveTextFile(path, text);
+    } else {
+        deleteFile(path);
+    }
+
+    updateMapsWithConnections(map);
+}
+
+void Project::updateMapsWithConnections(Map *map) {
+    if (map->connections.length() > 0) {
+        if (!mapsWithConnections.contains(map->name)) {
+            mapsWithConnections.append(map->name);
+        }
+    } else {
+        if (mapsWithConnections.contains(map->name)) {
+            mapsWithConnections.removeOne(map->name);
         }
     }
-    text += QString("\n");
-    text += QString("%1::\n").arg(map->connections_label);
-    text += QString("\t.4byte %1\n").arg(numValidConnections);
-    text += QString("\t.4byte %1\n").arg(connectionsListLabel);
-    saveTextFile(connections_path, text);
 }
 
 void Project::readMapAttributesTable() {
@@ -728,6 +753,7 @@ void Project::saveAllDataStructures() {
     saveAllMapAttributes();
     saveMapGroupsTable();
     saveMapConstantsHeader();
+    saveMapsWithConnections();
 }
 
 void Project::loadTilesetAssets(Tileset* tileset) {
@@ -939,6 +965,13 @@ void Project::appendTextFile(QString path, QString text) {
     }
 }
 
+void Project::deleteFile(QString path) {
+    QFile file(path);
+    if (file.exists() && !file.remove()) {
+        qDebug() << QString("Could not delete file '%1': ").arg(path) + file.errorString();
+    }
+}
+
 void Project::readMapGroups() {
     QString text = readTextFile(root + "/data/maps/_groups.inc");
     if (text.isNull()) {
@@ -1122,6 +1155,41 @@ void Project::readCDefinesSorted(QString filepath, QStringList prefixes, QString
         }
         *definesToSet = definesInverse.values();
     }
+}
+
+void Project::readMapsWithConnections() {
+    QString path = root + "/data/maps/connections.inc";
+    QString text = readTextFile(path);
+    if (text.isNull()) {
+        return;
+    }
+
+    mapsWithConnections.clear();
+    QRegularExpression re("data\\/maps\\/(?<mapName>\\w+)\\/connections.inc");
+    QList<QStringList>* includes = parseAsm(text);
+    for (QStringList values : *includes) {
+        if (values.length() != 2)
+            continue;
+
+        QRegularExpressionMatch match = re.match(values.value(1));
+        if (match.hasMatch()) {
+            QString mapName = match.captured("mapName");
+            mapsWithConnections.append(mapName);
+        }
+    }
+}
+
+void Project::saveMapsWithConnections() {
+    QString path = root + "/data/maps/connections.inc";
+    QString text = "";
+    for (QString mapName : mapsWithConnections) {
+        if (mapNamesToMapConstants->contains(mapName)) {
+            text += QString("\t.include \"data/maps/%1/connections.inc\"\n").arg(mapName);
+        } else {
+            qDebug() << QString("Failed to write connection include. %1 not a valid map name").arg(mapName);
+        }
+    }
+    saveTextFile(path, text);
 }
 
 QStringList Project::getSongNames() {

--- a/project.h
+++ b/project.h
@@ -97,6 +97,7 @@ private:
     QString getMapAttributesTableFilepath();
     QString getMapAssetsFilepath();
     void saveMapHeader(Map*);
+    void saveMapConnections(Map*);
     void saveMapAttributesTable();
     void updateMapAttributes(Map* map);
     void readCDefinesSorted(QString, QStringList, QStringList*);

--- a/project.h
+++ b/project.h
@@ -26,6 +26,7 @@ public:
     QStringList *itemNames = NULL;
     QStringList *flagNames = NULL;
     QStringList *varNames = NULL;
+    QStringList mapsWithConnections;
 
     QMap<QString, Map*> *map_cache;
     Map* loadMap(QString);
@@ -41,6 +42,7 @@ public:
     QString readTextFile(QString path);
     void saveTextFile(QString path, QString text);
     void appendTextFile(QString path, QString text);
+    void deleteFile(QString path);
 
     void readMapGroups();
     Map* addNewMapToGroup(QString mapName, int groupNum);
@@ -53,6 +55,7 @@ public:
     void readMapAttributesTable();
     void readAllMapAttributes();
     void readMapAttributes(Map*);
+    void readMapsWithConnections();
     void getTilesets(Map*);
     void loadTilesetAssets(Tileset*);
 
@@ -98,6 +101,8 @@ private:
     QString getMapAssetsFilepath();
     void saveMapHeader(Map*);
     void saveMapConnections(Map*);
+    void updateMapsWithConnections(Map*);
+    void saveMapsWithConnections();
     void saveMapAttributesTable();
     void updateMapAttributes(Map* map);
     void readCDefinesSorted(QString, QStringList, QStringList*);


### PR DESCRIPTION
This PR adds support for editing map connections.  It adds a new "Connections" tab to the main editor, which provides a click-and-drag interface for editing connections to the surrounding maps.