### PR TITLE
Events Editing

### DIFF
--- a/editor.cpp
+++ b/editor.cpp
@@ -1300,9 +1300,8 @@ void Editor::selectMapEvent(DraggablePixmapItem *object, bool toggle) {
 
 DraggablePixmapItem* Editor::addNewEvent(QString event_type) {
     if (project && map) {
-        Event *event = new Event;
+        Event *event = Event::createNewEvent(event_type, map->name);
         event->put("map_name", map->name);
-        event->put("event_type", event_type);
         map->addEvent(event);
         project->loadEventPixmaps(map->getAllEvents());
         DraggablePixmapItem *object = addMapEvent(event);
@@ -1320,7 +1319,6 @@ void Editor::deleteEvent(Event *event) {
     //selected_events->removeAll(event);
     //updateSelectedObjects();
 }
-
 
 // dunno how to detect bubbling. QMouseEvent::isAccepted seems to always be true
 // check if selected_events changed instead. this has the side effect of deselecting

--- a/editor.cpp
+++ b/editor.cpp
@@ -1,4 +1,5 @@
 #include "editor.h"
+#include "event.h"
 #include <QCheckBox>
 #include <QPainter>
 #include <QMouseEvent>
@@ -1295,10 +1296,6 @@ void Editor::selectMapEvent(DraggablePixmapItem *object, bool toggle) {
         }
         updateSelectedEvents();
     }
-}
-
-DraggablePixmapItem* Editor::addNewEvent() {
-    return addNewEvent("object");
 }
 
 DraggablePixmapItem* Editor::addNewEvent(QString event_type) {

--- a/editor.h
+++ b/editor.h
@@ -173,7 +173,7 @@ public:
         emit spriteChanged(event->pixmap);
     }
     void bind(QComboBox *combo, QString key) {
-        connect(combo, static_cast<void (QComboBox::*)(const QString &)>(&QComboBox::activated),
+        connect(combo, static_cast<void (QComboBox::*)(const QString &)>(&QComboBox::currentTextChanged),
                 this, [this, key](QString value){
             this->event->put(key, value);
         });

--- a/editor.h
+++ b/editor.h
@@ -61,7 +61,6 @@ public:
     DraggablePixmapItem *addMapEvent(Event *event);
     void selectMapEvent(DraggablePixmapItem *object);
     void selectMapEvent(DraggablePixmapItem *object, bool toggle);
-    DraggablePixmapItem *addNewEvent();
     DraggablePixmapItem *addNewEvent(QString event_type);
     void deleteEvent(Event *);
     void updateSelectedEvents();

--- a/editor.h
+++ b/editor.h
@@ -62,6 +62,7 @@ public:
     void selectMapEvent(DraggablePixmapItem *object);
     void selectMapEvent(DraggablePixmapItem *object, bool toggle);
     DraggablePixmapItem *addNewEvent(QString event_type);
+    Event* createNewEvent(QString event_type);
     void deleteEvent(Event *);
     void updateSelectedEvents();
     void redrawObject(DraggablePixmapItem *item);
@@ -107,6 +108,13 @@ private:
     void updateMirroredConnectionDirection(Connection*, QString);
     void updateMirroredConnectionMap(Connection*, QString);
     void updateMirroredConnection(Connection*, QString, QString, bool isDelete = false);
+    Event* createNewObjectEvent();
+    Event* createNewWarpEvent();
+    Event* createNewCoordScriptEvent();
+    Event* createNewCoordWeatherEvent();
+    Event* createNewSignEvent();
+    Event* createNewHiddenItemEvent();
+    Event* createNewSecretBaseEvent();
 
 private slots:
     void mouseEvent_map(QGraphicsSceneMouseEvent *event, MapPixmapItem *item);

--- a/event.cpp
+++ b/event.cpp
@@ -1,5 +1,13 @@
 #include "event.h"
 
+QString EventType::Object = "event_object";
+QString EventType::Warp = "event_warp";
+QString EventType::CoordScript = "event_trap";
+QString EventType::CoordWeather = "event_trap_weather";
+QString EventType::Sign = "event_sign";
+QString EventType::HiddenItem = "event_hidden_item";
+QString EventType::SecretBase = "event_secret_base";
+
 Event::Event()
 {
 }

--- a/event.cpp
+++ b/event.cpp
@@ -11,3 +11,203 @@ QString EventType::SecretBase = "event_secret_base";
 Event::Event()
 {
 }
+
+Event* Event::createNewEvent(QString event_type, QString map_name)
+{
+    Event *event;
+    if (event_type == EventType::Object) {
+        event = createNewObjectEvent();
+    } else if (event_type == EventType::Warp) {
+        event = createNewWarpEvent(map_name);
+    } else if (event_type == EventType::CoordScript) {
+        event = createNewCoordScriptEvent();
+    } else if (event_type == EventType::CoordWeather) {
+        event = createNewCoordWeatherEvent();
+    } else if (event_type == EventType::Sign) {
+        event = createNewSignEvent();
+    } else if (event_type == EventType::HiddenItem) {
+        event = createNewHiddenItemEvent();
+    } else if (event_type == EventType::SecretBase) {
+        event = createNewSecretBaseEvent();
+    }
+
+    event->setX(0);
+    event->setY(0);
+    event->put("elevation", 3);
+    return event;
+}
+
+Event* Event::createNewObjectEvent()
+{
+    Event *event = new Event;
+    event->put("event_group_type", "object_event_group");
+    event->put("event_type", EventType::Object);
+    event->put("sprite", "EVENT_OBJ_GFX_BOY_1");
+    event->put("behavior", "1");
+    event->put("radius_x", 0);
+    event->put("radius_y", 0);
+    event->put("script_label", "NULL");
+    event->put("event_flag", "0");
+    event->put("replacement", "0");
+    event->put("trainer_see_type", "0");
+    event->put("sight_radius_tree_id", 0);
+    return event;
+}
+
+Event* Event::createNewWarpEvent(QString map_name)
+{
+    Event *event = new Event;
+    event->put("event_group_type", "warp_event_group");
+    event->put("event_type", EventType::Warp);
+    event->put("destination_warp", 0);
+    event->put("destination_map_name", map_name);
+    return event;
+}
+
+Event* Event::createNewCoordScriptEvent()
+{
+    Event *event = new Event;
+    event->put("event_group_type", "coord_event_group");
+    event->put("event_type", EventType::CoordScript);
+    event->put("script_label", "NULL");
+    event->put("script_var", "VAR_TEMP_0");
+    event->put("script_var_value", "0");
+    return event;
+}
+
+Event* Event::createNewCoordWeatherEvent()
+{
+    Event *event = new Event;
+    event->put("event_group_type", "coord_event_group");
+    event->put("event_type", EventType::CoordWeather);
+    event->put("weather", "COORD_EVENT_WEATHER_SUNNY");
+    return event;
+}
+
+Event* Event::createNewSignEvent()
+{
+    Event *event = new Event;
+    event->put("event_group_type", "bg_event_group");
+    event->put("event_type", EventType::Sign);
+    event->put("player_facing_direction", "0");
+    event->put("script_label", "NULL");
+    return event;
+}
+
+Event* Event::createNewHiddenItemEvent()
+{
+    Event *event = new Event;
+    event->put("event_group_type", "bg_event_group");
+    event->put("event_type", EventType::HiddenItem);
+    event->put("item", "ITEM_POTION");
+    event->put("flag", "FLAG_HIDDEN_ITEM_0");
+    return event;
+}
+
+Event* Event::createNewSecretBaseEvent()
+{
+    Event *event = new Event;
+    event->put("event_group_type", "bg_event_group");
+    event->put("event_type", EventType::SecretBase);
+    event->put("secret_base_map", "SECRET_BASE_RED_CAVE2_1");
+    return event;
+}
+
+QString Event::buildObjectEventMacro(int item_index)
+{
+    int radius_x = this->getInt("radius_x");
+    int radius_y = this->getInt("radius_y");
+    uint16_t x = this->getInt("x");
+    uint16_t y = this->getInt("y");
+
+    QString text = "";
+    text += QString("\tobject_event %1").arg(item_index + 1);
+    text += QString(", %1").arg(this->get("sprite"));
+    text += QString(", %1").arg(this->get("replacement"));
+    text += QString(", %1").arg(x);
+    text += QString(", %1").arg(y);
+    text += QString(", %1").arg(this->get("elevation"));
+    text += QString(", %1").arg(this->get("behavior"));
+    text += QString(", %1").arg(radius_x);
+    text += QString(", %1").arg(radius_y);
+    text += QString(", %1").arg(this->get("trainer_see_type"));
+    text += QString(", %1").arg(this->get("sight_radius_tree_id"));
+    text += QString(", %1").arg(this->get("script_label"));
+    text += QString(", %1").arg(this->get("event_flag"));
+    text += "\n";
+    return text;
+}
+
+QString Event::buildWarpEventMacro(QMap<QString, QString> *mapNamesToMapConstants)
+{
+    QString text = "";
+    text += QString("\twarp_def %1").arg(this->get("x"));
+    text += QString(", %1").arg(this->get("y"));
+    text += QString(", %1").arg(this->get("elevation"));
+    text += QString(", %1").arg(this->get("destination_warp"));
+    text += QString(", %1").arg(mapNamesToMapConstants->value(this->get("destination_map_name")));
+    text += "\n";
+    return text;
+}
+
+QString Event::buildCoordScriptEventMacro()
+{
+    QString text = "";
+    text += QString("\tcoord_event %1").arg(this->get("x"));
+    text += QString(", %1").arg(this->get("y"));
+    text += QString(", %1").arg(this->get("elevation"));
+    text += QString(", 0");
+    text += QString(", %1").arg(this->get("script_var"));
+    text += QString(", %1").arg(this->get("script_var_value"));
+    text += QString(", 0");
+    text += QString(", %1").arg(this->get("script_label"));
+    text += "\n";
+    return text;
+}
+
+QString Event::buildCoordWeatherEventMacro()
+{
+    QString text = "";
+    text += QString("\tcoord_weather_event %1").arg(this->get("x"));
+    text += QString(", %1").arg(this->get("y"));
+    text += QString(", %1").arg(this->get("elevation"));
+    text += QString(", %1").arg(this->get("weather"));
+    text += "\n";
+    return text;
+}
+
+QString Event::buildSignEventMacro()
+{
+    QString text = "";
+    text += QString("\tbg_event %1").arg(this->get("x"));
+    text += QString(", %1").arg(this->get("y"));
+    text += QString(", %1").arg(this->get("elevation"));
+    text += QString(", %1").arg(this->get("player_facing_direction"));
+    text += QString(", 0");
+    text += QString(", %1").arg(this->get("script_label"));
+    text += "\n";
+    return text;
+}
+
+QString Event::buildHiddenItemEventMacro()
+{
+    QString text = "";
+    text += QString("\tbg_hidden_item_event %1").arg(this->get("x"));
+    text += QString(", %1").arg(this->get("y"));
+    text += QString(", %1").arg(this->get("elevation"));
+    text += QString(", %1").arg(this->get("item"));
+    text += QString(", %1").arg(this->get("flag"));
+    text += "\n";
+    return text;
+}
+
+QString Event::buildSecretBaseEventMacro()
+{
+    QString text = "";
+    text += QString("\tbg_secret_base_event %1").arg(this->get("x"));
+    text += QString(", %1").arg(this->get("y"));
+    text += QString(", %1").arg(this->get("elevation"));
+    text += QString(", %1").arg(this->get("secret_base_map"));
+    text += "\n";
+    return text;
+}

--- a/event.h
+++ b/event.h
@@ -5,11 +5,22 @@
 #include <QPixmap>
 #include <QMap>
 
+class EventType
+{
+public:
+    static QString Object;
+    static QString Warp;
+    static QString CoordScript;
+    static QString CoordWeather;
+    static QString Sign;
+    static QString HiddenItem;
+    static QString SecretBase;
+};
+
 class Event
 {
 public:
     Event();
-
 public:
     int x() {
         return getInt("x");

--- a/event.h
+++ b/event.h
@@ -4,6 +4,7 @@
 #include <QString>
 #include <QPixmap>
 #include <QMap>
+#include <QDebug>
 
 class EventType
 {
@@ -49,6 +50,23 @@ public:
     void put(QString key, QString value) {
         values.insert(key, value);
     }
+
+    static Event* createNewEvent(QString, QString);
+    static Event* createNewObjectEvent();
+    static Event* createNewWarpEvent(QString);
+    static Event* createNewCoordScriptEvent();
+    static Event* createNewCoordWeatherEvent();
+    static Event* createNewSignEvent();
+    static Event* createNewHiddenItemEvent();
+    static Event* createNewSecretBaseEvent();
+
+    QString buildObjectEventMacro(int);
+    QString buildWarpEventMacro(QMap<QString, QString>*);
+    QString buildCoordScriptEventMacro();
+    QString buildCoordWeatherEventMacro();
+    QString buildSignEventMacro();
+    QString buildHiddenItemEventMacro();
+    QString buildSecretBaseEventMacro();
 
     QMap<QString, QString> values;
     QPixmap pixmap;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -512,9 +512,7 @@ void MainWindow::addNewEvent(QString event_type)
     if (editor) {
         DraggablePixmapItem *object = editor->addNewEvent(event_type);
         if (object) {
-            //if (editor->selected_events->length()) {
-                editor->selectMapEvent(object, true);
-            //}
+            editor->selectMapEvent(object, false);
         }
         updateSelectedObjects();
     }
@@ -558,12 +556,13 @@ void MainWindow::updateSelectedObjects() {
         font.setCapitalization(QFont::Capitalize);
         frame->ui->label_name->setFont(font);
         QString event_type = item->event->get("event_type");
+        QString event_group_type = item->event->get("event_group_type");
         QString map_name = item->event->get("map_name");
         frame->ui->label_name->setText(
-            QString("%1 %2 %3")
+            QString("%1: %2 %3")
+                .arg(editor->project->getMap(map_name)->events.value(event_group_type).indexOf(item->event) + 1)
                 .arg(map_name)
                 .arg(event_type)
-                .arg(editor->project->getMap(map_name)->events.value(event_type).indexOf(item->event) + 1)
         );
 
         frame->ui->label_spritePixmap->setPixmap(item->event->pixmap);
@@ -578,13 +577,13 @@ void MainWindow::updateSelectedObjects() {
         field_labels["behavior"] = "Behavior";
         field_labels["radius_x"] = "Movement Radius X";
         field_labels["radius_y"] = "Movement Radius Y";
-        field_labels["property"] = "Property";
-        field_labels["sight_radius"] = "Sight Radius";
+        field_labels["trainer_see_type"] = "Trainer See Type";
+        field_labels["sight_radius_tree_id"] = "Sight Radius / Berry Tree ID";
         field_labels["destination_warp"] = "Destination Warp";
         field_labels["destination_map_name"] = "Destination Map";
         field_labels["script_var"] = "Var";
         field_labels["script_var_value"] = "Var Value";
-        field_labels["type"] = "Type";
+        field_labels["player_facing_direction"] = "Player Facing Direction";
         field_labels["item"] = "Item";
         field_labels["item_unknown5"] = "Unknown 5";
         field_labels["item_unknown6"] = "Unknown 6";
@@ -617,8 +616,8 @@ void MainWindow::updateSelectedObjects() {
             fields << "script_label";
             fields << "event_flag";
             fields << "replacement";
-            fields << "property";
-            fields << "sight_radius";
+            fields << "trainer_see_type";
+            fields << "sight_radius_tree_id";
         }
         else if (event_type == EventType::Warp) {
             fields << "destination_warp";
@@ -633,7 +632,7 @@ void MainWindow::updateSelectedObjects() {
             fields << "weather";
         }
         else if (event_type == EventType::Sign) {
-            fields << "type";
+            fields << "player_facing_direction";
             fields << "script_label";
         }
         else if (event_type == EventType::HiddenItem) {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -24,6 +24,10 @@ MainWindow::MainWindow(QWidget *parent) :
     QCoreApplication::setApplicationName("pretmap");
 
     ui->setupUi(this);
+
+    ui->newEventToolButton->initButton();
+    connect(ui->newEventToolButton, SIGNAL(newEventAdded(QString)), this, SLOT(addNewEvent(QString)));
+
     new QShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_Z), this, SLOT(redo()));
 
     editor = new Editor(ui);
@@ -503,10 +507,10 @@ void MainWindow::on_actionRedo_triggered()
     redo();
 }
 
-void MainWindow::on_toolButton_newObject_clicked()
+void MainWindow::addNewEvent(QString event_type)
 {
     if (editor) {
-        DraggablePixmapItem *object = editor->addNewEvent();
+        DraggablePixmapItem *object = editor->addNewEvent(event_type);
         if (object) {
             //if (editor->selected_events->length()) {
                 editor->selectMapEvent(object, true);
@@ -590,7 +594,7 @@ void MainWindow::updateSelectedObjects() {
 
         QStringList fields;
 
-        if (event_type == "object") {
+        if (event_type == EventType::Object) {
 
             frame->ui->sprite->setVisible(true);
             frame->ui->comboBox_sprite->addItems(event_obj_gfx_constants.keys());
@@ -616,27 +620,27 @@ void MainWindow::updateSelectedObjects() {
             fields << "property";
             fields << "sight_radius";
         }
-        else if (event_type == "warp") {
+        else if (event_type == EventType::Warp) {
             fields << "destination_warp";
             fields << "destination_map_name";
         }
-        else if (event_type == "trap") {
+        else if (event_type == EventType::CoordScript) {
             fields << "script_label";
             fields << "script_var";
             fields << "script_var_value";
         }
-        else if (event_type == "trap_weather") {
+        else if (event_type == EventType::CoordWeather) {
             fields << "weather";
         }
-        else if (event_type == "sign") {
+        else if (event_type == EventType::Sign) {
             fields << "type";
             fields << "script_label";
         }
-        else if (event_type == "event_hidden_item") {
+        else if (event_type == EventType::HiddenItem) {
             fields << "item";
             fields << "flag";
         }
-        else if (event_type == "event_secret_base") {
+        else if (event_type == EventType::SecretBase) {
             fields << "secret_base_map";
         }
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -56,10 +56,9 @@ private slots:
 
     void on_actionRedo_triggered();
 
-    void on_toolButton_newObject_clicked();
-
     void on_toolButton_deleteObject_clicked();
 
+    void addNewEvent(QString);
     void updateSelectedObjects();
 
     void on_toolButton_Paint_clicked();

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -60,7 +60,7 @@
         </sizepolicy>
        </property>
        <property name="currentIndex">
-        <number>0</number>
+        <number>1</number>
        </property>
        <property name="tabsClosable">
         <bool>false</bool>
@@ -904,13 +904,7 @@
                  <number>0</number>
                 </property>
                 <item>
-                 <widget class="QToolButton" name="toolButton_newObject">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
+                 <widget class="NewEventToolButton" name="newEventToolButton">
                   <property name="minimumSize">
                    <size>
                     <width>40</width>
@@ -918,7 +912,7 @@
                    </size>
                   </property>
                   <property name="text">
-                   <string>New</string>
+                   <string>New Object</string>
                   </property>
                   <property name="icon">
                    <iconset resource="resources/images.qrc">
@@ -1793,6 +1787,11 @@
    <class>GraphicsView</class>
    <extends>QGraphicsView</extends>
    <header>graphicsview.h</header>
+  </customwidget>
+  <customwidget>
+   <class>NewEventToolButton</class>
+   <extends>QToolButton</extends>
+   <header>neweventtoolbutton.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/map.cpp
+++ b/map.cpp
@@ -733,11 +733,6 @@ QList<Event *> Map::getAllEvents() {
     return all;
 }
 
-QList<Event *> Map::getEventsByType(QString type)
-{
-    return events.value(type);
-}
-
 void Map::removeEvent(Event *event) {
     for (QString key : events.keys()) {
         events[key].removeAll(event);
@@ -745,7 +740,7 @@ void Map::removeEvent(Event *event) {
 }
 
 void Map::addEvent(Event *event) {
-    events[event->get("event_type")].append(event);
+    events[event->get("event_group_type")].append(event);
 }
 
 bool Map::hasUnsavedChanges() {

--- a/map.cpp
+++ b/map.cpp
@@ -31,6 +31,26 @@ QString Map::mapConstantFromName(QString mapName) {
     return constantName;
 }
 
+QString Map::objectEventsLabelFromName(QString mapName)
+{
+    return QString("%1_EventObjects").arg(mapName);
+}
+
+QString Map::warpEventsLabelFromName(QString mapName)
+{
+    return QString("%1_MapWarps").arg(mapName);
+}
+
+QString Map::coordEventsLabelFromName(QString mapName)
+{
+    return QString("%1_MapCoordEvents").arg(mapName);
+}
+
+QString Map::bgEventsLabelFromName(QString mapName)
+{
+    return QString("%1_MapBGEvents").arg(mapName);
+}
+
 int Map::getWidth() {
     return layout->width.toInt(nullptr, 0);
 }

--- a/map.h
+++ b/map.h
@@ -129,12 +129,16 @@ public:
 public:
     void setName(QString mapName);
     static QString mapConstantFromName(QString mapName);
+    static QString objectEventsLabelFromName(QString mapName);
+    static QString warpEventsLabelFromName(QString mapName);
+    static QString coordEventsLabelFromName(QString mapName);
+    static QString bgEventsLabelFromName(QString mapName);
     int getWidth();
     int getHeight();
     Tileset* getBlockTileset(int);
-    int getBlockIndex(int layout_id);
-    int getSelectedBlockIndex(int layout_id);
-    int getDisplayedBlockIndex(int layout_id);
+    int getBlockIndex(int);
+    int getSelectedBlockIndex(int);
+    int getDisplayedBlockIndex(int);
     Metatile* getMetatile(int);
     QImage getMetatileImage(int);
     QImage getMetatileTile(int);
@@ -187,11 +191,6 @@ public:
     void undo();
     void redo();
     void commit();
-
-    QString object_events_label;
-    QString warps_label;
-    QString coord_events_label;
-    QString bg_events_label;
 
     QList<Event*> getAllEvents();
     void removeEvent(Event *event);

--- a/map.h
+++ b/map.h
@@ -194,7 +194,6 @@ public:
     QString bg_events_label;
 
     QList<Event*> getAllEvents();
-    QList<Event*> getEventsByType(QString type);
     void removeEvent(Event *event);
     void addEvent(Event *event);
     QMap<QString, QList<Event*>> events;

--- a/neweventtoolbutton.cpp
+++ b/neweventtoolbutton.cpp
@@ -1,0 +1,103 @@
+#include "neweventtoolbutton.h"
+#include <QMenu>
+#include <QDebug>
+
+// Custom QToolButton which has a context menu that expands to allow
+// selection of different types of map events.
+NewEventToolButton::NewEventToolButton(QWidget *parent) :
+    QToolButton(parent)
+{
+    setPopupMode(QToolButton::MenuButtonPopup);
+    QObject::connect(this, SIGNAL(triggered(QAction*)),
+                     this, SLOT(setDefaultAction(QAction*)));
+}
+
+void NewEventToolButton::initButton()
+{
+    // Add a context menu to select different types of map events.
+    this->newObjectAction = new QAction("New Object", this);
+    this->newObjectAction->setIcon(QIcon(":/icons/add.ico"));
+    connect(this->newObjectAction, SIGNAL(triggered(bool)), this, SLOT(newObject()));
+
+    this->newWarpAction = new QAction("New Warp", this);
+    this->newWarpAction->setIcon(QIcon(":/icons/add.ico"));
+    connect(this->newWarpAction, SIGNAL(triggered(bool)), this, SLOT(newWarp()));
+
+    this->newCoordScriptAction = new QAction("New Coord Script", this);
+    this->newCoordScriptAction->setIcon(QIcon(":/icons/add.ico"));
+    connect(this->newCoordScriptAction, SIGNAL(triggered(bool)), this, SLOT(newCoordScript()));
+
+    this->newCoordWeatherAction = new QAction("New Coord Weather", this);
+    this->newCoordWeatherAction->setIcon(QIcon(":/icons/add.ico"));
+    connect(this->newCoordWeatherAction, SIGNAL(triggered(bool)), this, SLOT(newCoordWeather()));
+
+    this->newSignAction = new QAction("New Sign", this);
+    this->newSignAction->setIcon(QIcon(":/icons/add.ico"));
+    connect(this->newSignAction, SIGNAL(triggered(bool)), this, SLOT(newSign()));
+
+    this->newHiddenItemAction = new QAction("New Hidden Item", this);
+    this->newHiddenItemAction->setIcon(QIcon(":/icons/add.ico"));
+    connect(this->newHiddenItemAction, SIGNAL(triggered(bool)), this, SLOT(newHiddenItem()));
+
+    this->newSecretBaseAction = new QAction("New Secret Base", this);
+    this->newSecretBaseAction->setIcon(QIcon(":/icons/add.ico"));
+    connect(this->newSecretBaseAction, SIGNAL(triggered(bool)), this, SLOT(newSecretBase()));
+
+    QMenu *alignMenu = new QMenu();
+    alignMenu->addAction(this->newObjectAction);
+    alignMenu->addAction(this->newWarpAction);
+    alignMenu->addAction(this->newCoordScriptAction);
+    alignMenu->addAction(this->newCoordWeatherAction);
+    alignMenu->addAction(this->newSignAction);
+    alignMenu->addAction(this->newHiddenItemAction);
+    alignMenu->addAction(this->newSecretBaseAction);
+    this->setMenu(alignMenu);
+    this->setDefaultAction(this->newObjectAction);
+}
+
+QString NewEventToolButton::getSelectedEventType()
+{
+    return this->selectedEventType;
+}
+
+void NewEventToolButton::newObject()
+{
+    this->selectedEventType = EventType::Object;
+    emit newEventAdded(this->selectedEventType);
+}
+
+void NewEventToolButton::newWarp()
+{
+    this->selectedEventType = EventType::Warp;
+    emit newEventAdded(this->selectedEventType);
+}
+
+void NewEventToolButton::newCoordScript()
+{
+    this->selectedEventType = EventType::CoordScript;
+    emit newEventAdded(this->selectedEventType);
+}
+
+void NewEventToolButton::newCoordWeather()
+{
+    this->selectedEventType = EventType::CoordWeather;
+    emit newEventAdded(this->selectedEventType);
+}
+
+void NewEventToolButton::newSign()
+{
+    this->selectedEventType = EventType::Sign;
+    emit newEventAdded(this->selectedEventType);
+}
+
+void NewEventToolButton::newHiddenItem()
+{
+    this->selectedEventType = EventType::HiddenItem;
+    emit newEventAdded(this->selectedEventType);
+}
+
+void NewEventToolButton::newSecretBase()
+{
+    this->selectedEventType = EventType::SecretBase;
+    emit newEventAdded(this->selectedEventType);
+}

--- a/neweventtoolbutton.h
+++ b/neweventtoolbutton.h
@@ -1,0 +1,35 @@
+#ifndef NEWEVENTTOOLBUTTON_H
+#define NEWEVENTTOOLBUTTON_H
+
+#include "event.h"
+#include <QToolButton>
+
+class NewEventToolButton : public QToolButton
+{
+    Q_OBJECT
+public:
+    explicit NewEventToolButton(QWidget *parent = 0);
+    void initButton();
+    QString getSelectedEventType();
+public slots:
+    void newObject();
+    void newWarp();
+    void newCoordScript();
+    void newCoordWeather();
+    void newSign();
+    void newHiddenItem();
+    void newSecretBase();
+signals:
+    void newEventAdded(QString);
+private:
+    QString selectedEventType;
+    QAction *newObjectAction;
+    QAction *newWarpAction;
+    QAction *newCoordScriptAction;
+    QAction *newCoordWeatherAction;
+    QAction *newSignAction;
+    QAction *newHiddenItemAction;
+    QAction *newSecretBaseAction;
+};
+
+#endif // NEWEVENTTOOLBUTTON_H

--- a/pretmap.pro
+++ b/pretmap.pro
@@ -25,7 +25,8 @@ SOURCES += main.cpp\
     editor.cpp \
     objectpropertiesframe.cpp \
     graphicsview.cpp \
-    parseutil.cpp
+    parseutil.cpp \
+    neweventtoolbutton.cpp
 
 HEADERS  += mainwindow.h \
     project.h \
@@ -39,7 +40,8 @@ HEADERS  += mainwindow.h \
     editor.h \
     objectpropertiesframe.h \
     graphicsview.h \
-    parseutil.h
+    parseutil.h \
+    neweventtoolbutton.h
 
 FORMS    += mainwindow.ui \
     objectpropertiesframe.ui

--- a/project.cpp
+++ b/project.cpp
@@ -1185,9 +1185,14 @@ void Project::loadEventPixmaps(QList<Event*> objects) {
 void Project::saveMapEvents(Map *map) {
     QString path = root + QString("/data/maps/%1/events.inc").arg(map->name);
     QString text = "";
+    QString objectEventsLabel = "0x0";
+    QString warpEventsLabel = "0x0";
+    QString coordEventsLabel = "0x0";
+    QString bgEventsLabel = "0x0";
 
     if (map->events["object_event_group"].length() > 0) {
-        text += QString("%1::\n").arg(map->object_events_label);
+        objectEventsLabel = Map::objectEventsLabelFromName(map->name);
+        text += QString("%1::\n").arg(objectEventsLabel);
         for (int i = 0; i < map->events["object_event_group"].length(); i++) {
             Event *object_event = map->events["object_event_group"].value(i);
             text += object_event->buildObjectEventMacro(i);
@@ -1196,7 +1201,8 @@ void Project::saveMapEvents(Map *map) {
     }
 
     if (map->events["warp_event_group"].length() > 0) {
-        text += QString("%1::\n").arg(map->warps_label);
+        warpEventsLabel = Map::warpEventsLabelFromName(map->name);
+        text += QString("%1::\n").arg(warpEventsLabel);
         for (Event *warp : map->events["warp_event_group"]) {
             text += warp->buildWarpEventMacro(mapNamesToMapConstants);
         }
@@ -1204,7 +1210,8 @@ void Project::saveMapEvents(Map *map) {
     }
 
     if (map->events["coord_event_group"].length() > 0) {
-        text += QString("%1::\n").arg(map->coord_events_label);
+        coordEventsLabel = Map::coordEventsLabelFromName(map->name);
+        text += QString("%1::\n").arg(coordEventsLabel);
         for (Event *event : map->events["coord_event_group"]) {
             QString event_type = event->get("event_type");
             if (event_type == EventType::CoordScript) {
@@ -1218,7 +1225,8 @@ void Project::saveMapEvents(Map *map) {
 
     if (map->events["bg_event_group"].length() > 0)
     {
-        text += QString("%1::\n").arg(map->bg_events_label);
+        bgEventsLabel = Map::bgEventsLabelFromName(map->name);
+        text += QString("%1::\n").arg(bgEventsLabel);
         for (Event *event : map->events["bg_event_group"]) {
             QString event_type = event->get("event_type");
             if (event_type == EventType::Sign) {
@@ -1234,10 +1242,10 @@ void Project::saveMapEvents(Map *map) {
 
     text += QString("%1::\n").arg(map->events_label);
     text += QString("\tmap_events %1, %2, %3, %4\n")
-            .arg(map->object_events_label)
-            .arg(map->warps_label)
-            .arg(map->coord_events_label)
-            .arg(map->bg_events_label);
+            .arg(objectEventsLabel)
+            .arg(warpEventsLabel)
+            .arg(coordEventsLabel)
+            .arg(bgEventsLabel);
 
     saveTextFile(path, text);
 }
@@ -1255,12 +1263,12 @@ void Project::readMapEvents(Map *map) {
     }
 
     QStringList *labels = getLabelValues(parseAsm(text), map->events_label);
-    map->object_events_label = labels->value(0);
-    map->warps_label = labels->value(1);
-    map->coord_events_label = labels->value(2);
-    map->bg_events_label = labels->value(3);
+    QString objectEventsLabel = labels->value(0);
+    QString warpEventsLabel = labels->value(1);
+    QString coordEventsLabel = labels->value(2);
+    QString bgEventsLabel = labels->value(3);
 
-    QList<QStringList> *object_events = getLabelMacros(parseAsm(text), map->object_events_label);
+    QList<QStringList> *object_events = getLabelMacros(parseAsm(text), objectEventsLabel);
     map->events["object_event_group"].clear();
     for (QStringList command : *object_events) {
         if (command.value(0) == "object_event") {
@@ -1285,7 +1293,7 @@ void Project::readMapEvents(Map *map) {
         }
     }
 
-    QList<QStringList> *warps = getLabelMacros(parseAsm(text), map->warps_label);
+    QList<QStringList> *warps = getLabelMacros(parseAsm(text), warpEventsLabel);
     map->events["warp_event_group"].clear();
     for (QStringList command : *warps) {
         if (command.value(0) == "warp_def") {
@@ -1310,7 +1318,7 @@ void Project::readMapEvents(Map *map) {
         }
     }
 
-    QList<QStringList> *coords = getLabelMacros(parseAsm(text), map->coord_events_label);
+    QList<QStringList> *coords = getLabelMacros(parseAsm(text), coordEventsLabel);
     map->events["coord_event_group"].clear();
     for (QStringList command : *coords) {
         if (command.value(0) == "coord_event") {
@@ -1349,7 +1357,7 @@ void Project::readMapEvents(Map *map) {
         }
     }
 
-    QList<QStringList> *bgs = getLabelMacros(parseAsm(text), map->bg_events_label);
+    QList<QStringList> *bgs = getLabelMacros(parseAsm(text), bgEventsLabel);
     map->events["bg_event_group"].clear();
     for (QStringList command : *bgs) {
         if (command.value(0) == "bg_event") {
@@ -1394,10 +1402,6 @@ void Project::readMapEvents(Map *map) {
 }
 
 void Project::setNewMapEvents(Map *map) {
-    map->object_events_label = "0x0";
-    map->warps_label = "0x0";
-    map->coord_events_label = "0x0";
-    map->bg_events_label = "0x0";
     map->events["object_event_group"].clear();
     map->events["warp_event_group"].clear();
     map->events["coord_event_group"].clear();

--- a/project.cpp
+++ b/project.cpp
@@ -1152,17 +1152,17 @@ void Project::loadEventPixmaps(QList<Event*> objects) {
             continue;
         }
         QString event_type = object->get("event_type");
-        if (event_type == "object") {
+        if (event_type == EventType::Object) {
             object->pixmap = QPixmap(":/images/Entities_16x16.png").copy(0, 0, 16, 16);
-        } else if (event_type == "warp") {
+        } else if (event_type == EventType::Warp) {
             object->pixmap = QPixmap(":/images/Entities_16x16.png").copy(16, 0, 16, 16);
-        } else if (event_type == "trap" || event_type == "trap_weather") {
+        } else if (event_type == EventType::CoordScript || event_type == EventType::CoordWeather) {
             object->pixmap = QPixmap(":/images/Entities_16x16.png").copy(32, 0, 16, 16);
-        } else if (event_type == "sign" || event_type == "event_hidden_item" || event_type == "event_secret_base") {
+        } else if (event_type == EventType::Sign || event_type == EventType::HiddenItem || event_type == EventType::SecretBase) {
             object->pixmap = QPixmap(":/images/Entities_16x16.png").copy(48, 0, 16, 16);
         }
 
-        if (event_type == "object") {
+        if (event_type == EventType::Object) {
             int sprite_id = constants.value(object->get("sprite"));
 
             QString info_label = pointers.value(sprite_id).replace("&", "");
@@ -1178,10 +1178,8 @@ void Project::loadEventPixmaps(QList<Event*> objects) {
                     object->pixmap = pixmap;
                 }
             }
-
         }
     }
-
 }
 
 void Project::saveMapEvents(Map *map) {
@@ -1331,7 +1329,7 @@ void Project::readMapEvents(Map *map) {
             object->put("script_label", command.value(i++));
             object->put("event_flag", command.value(i++));
 
-            object->put("event_type", "object");
+            object->put("event_type", EventType::Object);
             map->events["object"].append(object);
         }
     }
@@ -1352,7 +1350,7 @@ void Project::readMapEvents(Map *map) {
             QString mapConstant = command.value(i++);
             if (mapConstantsToMapNames->contains(mapConstant)) {
                 warp->put("destination_map_name", mapConstantsToMapNames->value(mapConstant));
-                warp->put("event_type", "warp");
+                warp->put("event_type", EventType::Warp);
                 map->events["warp"].append(warp);
             } else {
                 qDebug() << QString("Destination map constant '%1' is invalid for warp").arg(mapConstant);
@@ -1383,7 +1381,7 @@ void Project::readMapEvents(Map *map) {
             //coord_unknown3
             //coord_unknown4
 
-            coord->put("event_type", "trap");
+            coord->put("event_type", EventType::CoordScript);
             map->events["trap"].append(coord);
         } else if (command.value(0) == "coord_weather_event") {
             Event *coord = new Event;
@@ -1393,7 +1391,7 @@ void Project::readMapEvents(Map *map) {
             coord->put("y", command.value(i++));
             coord->put("elevation", command.value(i++));
             coord->put("weather", command.value(i++));
-            coord->put("event_type", "trap_weather");
+            coord->put("event_type", EventType::CoordWeather);
             map->events["trap_weather"].append(coord);
         }
     }
@@ -1414,7 +1412,7 @@ void Project::readMapEvents(Map *map) {
             i++;
             bg->put("script_label", command.value(i++));
             //sign_unknown7
-            bg->put("event_type", "sign");
+            bg->put("event_type", EventType::Sign);
             map->events["sign"].append(bg);
         } else if (command.value(0) == "bg_hidden_item_event") {
             Event *bg = new Event;
@@ -1425,7 +1423,7 @@ void Project::readMapEvents(Map *map) {
             bg->put("elevation", command.value(i++));
             bg->put("item", command.value(i++));
             bg->put("flag", command.value(i++));
-            bg->put("event_type", "event_hidden_item");
+            bg->put("event_type", EventType::HiddenItem);
             map->events["event_hidden_item"].append(bg);
         } else if (command.value(0) == "bg_secret_base_event") {
             Event *bg = new Event;
@@ -1435,7 +1433,7 @@ void Project::readMapEvents(Map *map) {
             bg->put("y", command.value(i++));
             bg->put("elevation", command.value(i++));
             bg->put("secret_base_map", command.value(i++));
-            bg->put("event_type", "event_secret_base");
+            bg->put("event_type", EventType::SecretBase);
             map->events["event_secret_base"].append(bg);
         }
     }


### PR DESCRIPTION
1. Allow adding all types of map events
2. Properly bind to the event combobox values
3. Properly preserve order of events so that saving an unaltered game still matches the original ROM
![image](https://user-images.githubusercontent.com/2229288/42413119-69026ca0-81df-11e8-95dc-91d8f35b6461.png)
