### PR TITLE
Map resizing and improved floodfill

### DIFF
--- a/editor.cpp
+++ b/editor.cpp
@@ -58,6 +58,7 @@ void Editor::setEditingMap() {
 void Editor::setEditingCollision() {
     current_view = collision_item;
     if (collision_item) {
+        displayMapConnections();
         collision_item->draw();
         collision_item->setVisible(true);
         setConnectionsVisibility(true);

--- a/editor.cpp
+++ b/editor.cpp
@@ -321,8 +321,8 @@ void Editor::setMap(QString map_name) {
     }
     if (project) {
         map = project->loadMap(map_name);
-        displayMap();
         selected_events->clear();
+        displayMap();
         updateSelectedEvents();
     }
 }

--- a/editor.cpp
+++ b/editor.cpp
@@ -26,13 +26,15 @@ void Editor::save() {
 
 void Editor::undo() {
     if (current_view) {
-        ((MapPixmapItem*)current_view)->undo();
+        map->undo();
+        map_item->draw();
     }
 }
 
 void Editor::redo() {
     if (current_view) {
-        ((MapPixmapItem*)current_view)->redo();
+        map->redo();
+        map_item->draw();
     }
 }
 
@@ -1213,20 +1215,6 @@ void MapPixmapItem::select(QGraphicsSceneMouseEvent *event) {
 void MapPixmapItem::draw(bool ignoreCache) {
     if (map) {
         setPixmap(map->render(ignoreCache));
-    }
-}
-
-void MapPixmapItem::undo() {
-    if (map) {
-        map->undo();
-        draw();
-    }
-}
-
-void MapPixmapItem::redo() {
-    if (map) {
-        map->redo();
-        draw();
     }
 }
 

--- a/editor.h
+++ b/editor.h
@@ -252,8 +252,6 @@ public:
     virtual void floodFill(QGraphicsSceneMouseEvent*);
     virtual void pick(QGraphicsSceneMouseEvent*);
     virtual void select(QGraphicsSceneMouseEvent*);
-    virtual void undo();
-    virtual void redo();
     virtual void draw(bool ignoreCache = false);
 
 private:

--- a/editor.h
+++ b/editor.h
@@ -250,6 +250,8 @@ public:
     QList<QPoint> selection;
     virtual void paint(QGraphicsSceneMouseEvent*);
     virtual void floodFill(QGraphicsSceneMouseEvent*);
+    void _floodFill(int x, int y);
+    void _floodFillSmartPath(int initialX, int initialY);
     virtual void pick(QGraphicsSceneMouseEvent*);
     virtual void select(QGraphicsSceneMouseEvent*);
     virtual void draw(bool ignoreCache = false);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -909,3 +909,8 @@ void MainWindow::on_pushButton_clicked()
         onMapNeedsRedrawing(editor->map);
     }
 }
+
+void MainWindow::on_checkBox_smartPaths_stateChanged(int selected)
+{
+    editor->map->smart_paths_enabled = selected == Qt::Checked;
+}

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -15,6 +15,8 @@
 #include <QSpacerItem>
 #include <QFont>
 #include <QScrollBar>
+#include <QMessageBox>
+#include <QDialogButtonBox>
 
 MainWindow::MainWindow(QWidget *parent) :
     QMainWindow(parent),
@@ -837,4 +839,33 @@ void MainWindow::on_comboBox_PrimaryTileset_activated(const QString &tilesetLabe
 void MainWindow::on_comboBox_SecondaryTileset_activated(const QString &tilesetLabel)
 {
     editor->updateSecondaryTileset(tilesetLabel);
+}
+
+void MainWindow::on_pushButton_clicked()
+{
+    QDialog dialog(this, Qt::WindowTitleHint | Qt::WindowCloseButtonHint);
+    dialog.setWindowTitle("Change Map Dimensions");
+    dialog.setWindowModality(Qt::NonModal);
+
+    QFormLayout form(&dialog);
+
+    QSpinBox *widthSpinBox = new QSpinBox();
+    QSpinBox *heightSpinBox = new QSpinBox();
+    widthSpinBox->setValue(editor->map->getWidth());
+    heightSpinBox->setValue(editor->map->getHeight());
+    widthSpinBox->setMinimum(1);
+    heightSpinBox->setMinimum(1);
+    widthSpinBox->setMaximum(255);
+    heightSpinBox->setMaximum(255);
+    form.addRow(new QLabel("Width"), widthSpinBox);
+    form.addRow(new QLabel("Height"), heightSpinBox);
+
+    QDialogButtonBox buttonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal, &dialog);
+    form.addRow(&buttonBox);
+    connect(&buttonBox, SIGNAL(accepted()), &dialog, SLOT(accept()));
+    connect(&buttonBox, SIGNAL(rejected()), &dialog, SLOT(reject()));
+
+    if (dialog.exec() == QDialog::Accepted) {
+        qDebug() << "Change width";
+    }
 }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -38,6 +38,7 @@ private slots:
 
     void onLoadMapRequested(QString, QString);
     void onMapChanged(Map *map);
+    void onMapNeedsRedrawing(Map *map);
 
     void on_action_Save_triggered();
     void on_tabWidget_2_currentChanged(int index);
@@ -102,6 +103,7 @@ private:
     Editor *editor = NULL;
     QIcon* mapIcon;
     void setMap(QString);
+    void redrawMapScene();
     void loadDataStructures();
     void populateMapList();
     QString getExistingDirectory(QString);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -93,6 +93,8 @@ private slots:
 
     void on_comboBox_SecondaryTileset_activated(const QString &arg1);
 
+    void on_pushButton_clicked();
+
 private:
     Ui::MainWindow *ui;
     QStandardItemModel *mapListModel;

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -96,6 +96,8 @@ private slots:
 
     void on_pushButton_clicked();
 
+    void on_checkBox_smartPaths_stateChanged(int selected);
+
 private:
     Ui::MainWindow *ui;
     QStandardItemModel *mapListModel;

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -228,9 +228,19 @@
                  </widget>
                 </item>
                 <item>
-                 <widget class="QCheckBox" name="checkBox_ToggleGrid">
+                 <widget class="QCheckBox" name="checkBox_smartPaths">
                   <property name="styleSheet">
                    <string notr="true">margin-left: 10px</string>
+                  </property>
+                  <property name="text">
+                   <string>Smart Paths</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="checkBox_ToggleGrid">
+                  <property name="styleSheet">
+                   <string notr="true"/>
                   </property>
                   <property name="text">
                    <string>Show Grid</string>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -250,6 +250,13 @@
                   </property>
                  </spacer>
                 </item>
+                <item>
+                 <widget class="QPushButton" name="pushButton">
+                  <property name="text">
+                   <string>Change Dimensions</string>
+                  </property>
+                 </widget>
+                </item>
                </layout>
               </widget>
              </item>
@@ -291,7 +298,7 @@
                      <x>0</x>
                      <y>0</y>
                      <width>436</width>
-                     <height>621</height>
+                     <height>620</height>
                     </rect>
                    </property>
                    <layout class="QGridLayout" name="gridLayout_8">

--- a/map.cpp
+++ b/map.cpp
@@ -427,6 +427,30 @@ QPixmap Map::renderMetatiles() {
     return QPixmap::fromImage(image);
 }
 
+void Map::setDimensions(int newWidth, int newHeight) {
+    int oldWidth = getWidth();
+    int oldHeight = getHeight();
+
+    Blockdata* newBlockData = new Blockdata;
+
+    for (int y = 0; y < newHeight; y++)
+    for (int x = 0; x < newWidth; x++) {
+        if (x < oldWidth && y < oldHeight) {
+            int index = y * oldWidth + x;
+            newBlockData->addBlock(layout->blockdata->blocks->value(index));
+        } else {
+            newBlockData->addBlock(0);
+        }
+    }
+
+    layout->blockdata->copyFrom(newBlockData);
+    layout->width = QString::number(newWidth);
+    layout->height = QString::number(newHeight);
+    commit();
+
+    emit mapChanged(this);
+}
+
 Block* Map::getBlock(int x, int y) {
     if (layout->blockdata && layout->blockdata->blocks) {
         if (x >= 0 && x < getWidth())

--- a/map.cpp
+++ b/map.cpp
@@ -389,7 +389,7 @@ void Map::drawSelection(int i, int w, int selectionWidth, int selectionHeight, Q
     int y = i / w;
     painter->save();
 
-    QColor penColor = smart_paths_enabled ? QColor(0xff, 0x0, 0xff) : QColor(0xff, 0xff, 0xff);
+    QColor penColor = QColor(0xff, 0xff, 0xff);
     painter->setPen(penColor);
     int rectWidth = selectionWidth * 16;
     int rectHeight = selectionHeight * 16;
@@ -474,38 +474,6 @@ void Map::_setBlock(int x, int y, Block block) {
     int i = y * getWidth() + x;
     if (layout->blockdata && layout->blockdata->blocks) {
         layout->blockdata->blocks->replace(i, block);
-    }
-}
-
-void Map::_floodFill(int x, int y, uint tile) {
-    QList<QPoint> todo;
-    todo.append(QPoint(x, y));
-    while (todo.length()) {
-            QPoint point = todo.takeAt(0);
-            x = point.x();
-            y = point.y();
-            Block *block = getBlock(x, y);
-            if (block == NULL) {
-                continue;
-            }
-            uint old_tile = block->tile;
-            if (old_tile == tile) {
-                continue;
-            }
-            block->tile = tile;
-            _setBlock(x, y, *block);
-            if ((block = getBlock(x + 1, y)) && block->tile == old_tile) {
-                todo.append(QPoint(x + 1, y));
-            }
-            if ((block = getBlock(x - 1, y)) && block->tile == old_tile) {
-                todo.append(QPoint(x - 1, y));
-            }
-            if ((block = getBlock(x, y + 1)) && block->tile == old_tile) {
-                todo.append(QPoint(x, y + 1));
-            }
-            if ((block = getBlock(x, y - 1)) && block->tile == old_tile) {
-                todo.append(QPoint(x, y - 1));
-            }
     }
 }
 
@@ -662,14 +630,6 @@ void Map::setBlock(int x, int y, Block block) {
     Block *old_block = getBlock(x, y);
     if (old_block && (*old_block) != block) {
         _setBlock(x, y, block);
-        commit();
-    }
-}
-
-void Map::floodFill(int x, int y, uint tile) {
-    Block *block = getBlock(x, y);
-    if (block && block->tile != tile) {
-        _floodFill(x, y, tile);
         commit();
     }
 }

--- a/map.h
+++ b/map.h
@@ -184,8 +184,6 @@ public:
     void setBlock(int x, int y, Block block);
     void _setBlock(int x, int y, Block block);
 
-    void floodFill(int x, int y, uint tile);
-    void _floodFill(int x, int y, uint tile);
     void floodFillCollision(int x, int y, uint collision);
     void _floodFillCollision(int x, int y, uint collision);
     void floodFillElevation(int x, int y, uint elevation);

--- a/map.h
+++ b/map.h
@@ -10,6 +10,17 @@
 #include <QDebug>
 #include <QGraphicsPixmapItem>
 
+class HistoryItem {
+public:
+    Blockdata *metatiles;
+    short layoutWidth;
+    short layoutHeight;
+    HistoryItem(Blockdata *metatiles_, short layoutWidth_, short layoutHeight_) {
+        this->metatiles = metatiles_;
+        this->layoutWidth = layoutWidth_;
+        this->layoutHeight = layoutHeight_;
+    }
+};
 
 template <typename T>
 class History {
@@ -182,7 +193,7 @@ public:
     void floodFillCollisionElevation(int x, int y, uint collision, uint elevation);
     void _floodFillCollisionElevation(int x, int y, uint collision, uint elevation);
 
-    History<Blockdata*> history;
+    History<HistoryItem*> history;
     void undo();
     void redo();
     void commit();
@@ -194,7 +205,8 @@ public:
 
     QList<Connection*> connections;
     QPixmap renderConnection(Connection);
-    void setDimensions(int, int);
+    void setNewDimensionsBlockdata(int newWidth, int newHeight);
+    void setDimensions(int newWidth, int newHeight, bool setNewBlockData = true);
 
     QPixmap renderBorder();
     void cacheBorder();
@@ -213,6 +225,7 @@ signals:
     void paintTileChanged(Map *map);
     void paintCollisionChanged(Map *map);
     void mapChanged(Map *map);
+    void mapNeedsRedrawing(Map *map);
     void statusBarMessage(QString);
 
 public slots:

--- a/map.h
+++ b/map.h
@@ -194,6 +194,7 @@ public:
 
     QList<Connection*> connections;
     QPixmap renderConnection(Connection);
+    void setDimensions(int, int);
 
     QPixmap renderBorder();
     void cacheBorder();


### PR DESCRIPTION
1. Support modifying map width/height
2. Make floodfill respect multi-block selections, including smart-path mode
3. Make edit/undo history respect map dimensions
4. Smart-path mode is now a checkbox, rather than holding down right mouse button.

Video showing it in action:
https://youtu.be/ediHkzOxGRU